### PR TITLE
Add support for Authorization header authentication

### DIFF
--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -37,6 +37,12 @@ def main():
         help="HTTP header for clients to send the Bugzilla API key. Defaults to 'ApiKey' or MCP_API_KEY_HEADER environment variable.",
     )
 
+    parser.add_argument(
+        "--use-auth-header",
+        action="store_true",
+        help="Use Authorization: Bearer header instead of api_key query parameter (required for some Bugzilla instances)"
+    )
+
     args = parser.parse_args()
 
     # The default behavior of argparse with os.getenv already handles the priority:

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -58,16 +58,22 @@ mcp_log.propagate = False
 class Bugzilla:
     """Async Bugzilla API client"""
 
-    def __init__(self, url: str, api_key: str):
+    def __init__(self, url: str, api_key: str, use_auth_header: bool = False):
         self.base_url = url.rstrip("/")
         self.api_url = f"{self.base_url}/rest"
         self.api_key = api_key
+        params={},
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        if use_auth_header:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        else:
+            params["api_key"] = self.api_key
         # We'll use a single client for the instance
         self.client = httpx.AsyncClient(
             base_url=self.api_url,
-            params={"api_key": self.api_key},
+            params=params,
             timeout=30.0,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            headers=headers,
             transport=RetryTransport(),
         )
 

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -41,7 +41,11 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
         raise ValidationError(f"`{api_key_header}` header is required")
 
     mcp_log.debug("api_key: Found")
-    bz = Bugzilla(url=base_url, api_key=api_key_value)
+    bz = Bugzilla(
+        url=base_url,
+        api_key=api_key_value,
+        use_auth_header=cli_args.get("use_auth_header", False)
+    )
     try:
         yield bz
     finally:


### PR DESCRIPTION
Some Bugzilla instances require `Authorization: Bearer` header instead of api_key query parameters. Add CLI flag to support both methods while maintaining backward compatibility.