### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openSUSE/mcp-bugzilla/security/code-scanning/1](https://github.com/openSUSE/mcp-bugzilla/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal scopes required. For this workflow, the steps only need to read the repository contents to run tests, so `contents: read` is sufficient. We can set this at the workflow root so it applies to all jobs, or at the job level; using the root keeps things concise and still allows overriding per-job later if needed.

The best targeted fix without altering existing functionality is to insert a top-level `permissions:` section directly under the workflow `name:` (before `on:`). This will restrict the `GITHUB_TOKEN` for all jobs (including the `test` job) to read-only access to repository contents, which is compatible with `actions/checkout` and the rest of the steps. No other code or steps need to change, and no additional imports or methods are required since this is a YAML configuration change only.

Concretely: edit `.github/workflows/tests.yml` to add:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Tests`). No other regions of the file need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
