### PR TITLE
Add comprehensive write operations to Bugzilla MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,57 @@ The server provides the following tools for interacting with Bugzilla:
   - **Returns**: A dictionary containing the ID of the newly created comment
   - **Example**: `add_comment(12345, "Fixed in version 2.0", is_private=False)`
 
+#### Write Operations
+
+**Note**: Write operations require appropriate Bugzilla permissions. These tools enable bug management and workflow automation.
+
+* **`update_bug_status(bug_id: int, status: str, resolution: str = None, comment: str = "")`**: Updates the status of a bug with optional comment.
+
+  + **Parameters**:
+    - `bug_id`: The bug ID to update
+    - `status`: New status (e.g., `NEW`, `ASSIGNED`, `MODIFIED`, `ON_QA`, `VERIFIED`, `CLOSED`)
+    - `resolution`: Required when status is `CLOSED` (e.g., `FIXED`, `WONTFIX`, `NOTABUG`, `DUPLICATE`)
+    - `comment`: Optional comment explaining the status change
+  + **Returns**: A dictionary containing the updated bug fields
+  + **Example**: `update_bug_status(12345, "CLOSED", resolution="FIXED", comment="Fixed in version 2.0")`
+
+* **`assign_bug(bug_id: int, assignee: str, comment: str = "")`**: Assigns a bug to a user.
+
+  + **Parameters**:
+    - `bug_id`: The bug ID to assign
+    - `assignee`: Email address of the assignee
+    - `comment`: Optional comment explaining the assignment
+  + **Returns**: A dictionary containing the updated bug fields
+  + **Example**: `assign_bug(12345, "developer@example.com", comment="You're the expert on this component")`
+
+* **`update_bug_fields(bug_id: int, priority: str = None, severity: str = None, resolution: str = None, comment: str = "")`**: Updates various bug fields.
+
+  + **Parameters**:
+    - `bug_id`: The bug ID to update
+    - `priority`: Priority level (e.g., `urgent`, `high`, `medium`, `low`, `unspecified`)
+    - `severity`: Severity level (e.g., `urgent`, `high`, `medium`, `low`, `unspecified`)
+    - `resolution`: Resolution (only for closed bugs)
+    - `comment`: Optional comment explaining the changes
+  + **Returns**: A dictionary containing the updated bug fields
+  + **Example**: `update_bug_fields(12345, priority="high", severity="urgent", comment="Escalating due to customer impact")`
+
+* **`add_cc_to_bug(bug_id: int, cc_email: str)`**: Adds an email address to the CC list of a bug.
+
+  + **Parameters**:
+    - `bug_id`: The bug ID
+    - `cc_email`: Email address to add to CC list
+  + **Returns**: A dictionary containing the updated bug fields
+  + **Example**: `add_cc_to_bug(12345, "manager@example.com")`
+
+* **`mark_as_duplicate(bug_id: int, duplicate_of: int, comment: str = "")`**: Marks a bug as a duplicate of another bug and closes it.
+
+  + **Parameters**:
+    - `bug_id`: The bug ID to mark as duplicate
+    - `duplicate_of`: The bug ID this is a duplicate of
+    - `comment`: Optional comment (auto-generated if not provided)
+  + **Returns**: A dictionary containing the updated bug fields including status `CLOSED`, resolution `DUPLICATE`, and `dupe_of` reference
+  + **Example**: `mark_as_duplicate(12345, 789012, comment="Same root cause as the original report")`
+
 #### Bug Search
 
 - **`bugs_quicksearch(query: str, status: str = "ALL", include_fields: str = "...", limit: int = 50, offset: int = 0)`**: Executes a search for bugs using Bugzilla's powerful [quicksearch syntax](https://bugzilla.readthedocs.io/en/latest/using/finding.html#quicksearch).
@@ -383,6 +434,38 @@ curl -X POST http://127.0.0.1:8000/mcp/ \
   -H "ApiKey: YOUR_API_KEY_HERE" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "server_url"}, "id": 1}'
+```
+
+### Example 7: Update Bug Status
+```python
+# Close a bug as fixed
+result = client.call_tool("update_bug_status", {
+    "bug_id": 12345,
+    "status": "CLOSED",
+    "resolution": "FIXED",
+    "comment": "Fixed in commit abc123"
+})
+```
+
+### Example 8: Assign a Bug
+```python
+# Assign bug to a developer
+result = client.call_tool("assign_bug", {
+    "bug_id": 12345,
+    "assignee": "developer@example.com",
+    "comment": "Please review this regression"
+})
+```
+
+### Example 9: Mark as Duplicate
+```python
+# Mark bug as duplicate and close it
+result = client.call_tool("mark_as_duplicate", {
+    "bug_id": 12345,
+    "duplicate_of": 67890,
+    "comment": "This is a duplicate of the original report"
+})
+# Bug is automatically closed with resolution DUPLICATE
 ```
 
 ## Troubleshooting

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -188,3 +188,29 @@ class Bugzilla:
         bugs = r.json().get("bugs", [])
         mcp_log.info(f"[BZ-RES] Found {len(bugs)} bugs")
         return bugs
+
+    async def update_bug(self, bug_id: int, updates: dict[str, Any], comment: str = "") -> dict[str, Any]:
+        """Update bug fields. Optionally add a comment with the update."""
+        payload = updates.copy()
+        if comment:
+            payload["comment"] = {"body": comment}
+
+        url = f"/bug/{bug_id}"
+        mcp_log.info(f"[BZ-REQ] PUT {self.api_url}{url} json={payload}")
+
+        try:
+            r = await self.client.put(url, json=payload)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        data = r.json()
+        mcp_log.info("[BZ-RES] Bug updated successfully")
+        mcp_log.debug(f"[BZ-RES] {data}")
+        return data

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -228,6 +228,164 @@ async def summarize_bug_prompt(id: int, bz: Bugzilla = Depends(get_bz)) -> str:
         raise PromptError(f"Summarize Comments Failed\nReason: {e}")
 
 
+@mcp.tool()
+async def update_bug_status(
+    bug_id: int,
+    status: str,
+    resolution: Optional[str] = None,
+    comment: str = "",
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Update the status of a bug. Optionally add a comment explaining the status change.
+
+    Valid statuses: NEW, ASSIGNED, MODIFIED, ON_QA, VERIFIED, CLOSED
+    For CLOSED, you MUST also provide a resolution (FIXED, WONTFIX, NOTABUG, DUPLICATE, etc.)
+
+    Args:
+        bug_id: Bug ID to update
+        status: New status
+        resolution: Resolution (required when status is CLOSED)
+        comment: Optional comment explaining the change
+    """
+    mcp_log.info(
+        f"[LLM-REQ] update_bug_status(bug_id={bug_id}, status='{status}', resolution={resolution}, comment='{comment[:50] if comment else ''}...')"
+    )
+
+    updates = {"status": status}
+    if resolution:
+        updates["resolution"] = resolution
+
+    # Validate: CLOSED requires resolution
+    if status == "CLOSED" and not resolution:
+        raise ToolError("Resolution is required when setting status to CLOSED (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE)")
+
+    try:
+        result = await bz.update_bug(bug_id, updates, comment)
+        return result
+    except Exception as e:
+        raise ToolError(f"Failed to update bug status\n{e}")
+
+
+@mcp.tool()
+async def assign_bug(
+    bug_id: int,
+    assignee: str,
+    comment: str = "",
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Assign a bug to a user. Optionally add a comment.
+
+    Args:
+        bug_id: Bug ID to assign
+        assignee: Email address of the assignee
+        comment: Optional comment explaining the assignment
+    """
+    mcp_log.info(
+        f"[LLM-REQ] assign_bug(bug_id={bug_id}, assignee='{assignee}')"
+    )
+    try:
+        result = await bz.update_bug(bug_id, {"assigned_to": assignee}, comment)
+        return result
+    except Exception as e:
+        raise ToolError(f"Failed to assign bug\n{e}")
+
+
+@mcp.tool()
+async def update_bug_fields(
+    bug_id: int,
+    priority: Optional[str] = None,
+    severity: Optional[str] = None,
+    resolution: Optional[str] = None,
+    comment: str = "",
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Update various bug fields. All fields are optional.
+
+    Args:
+        bug_id: Bug ID to update
+        priority: Priority (e.g., urgent, high, medium, low, unspecified)
+        severity: Severity (e.g., urgent, high, medium, low, unspecified)
+        resolution: Resolution (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE) - only for closed bugs
+        comment: Optional comment explaining the changes
+    """
+    mcp_log.info(
+        f"[LLM-REQ] update_bug_fields(bug_id={bug_id}, priority={priority}, severity={severity}, resolution={resolution})"
+    )
+
+    updates = {}
+    if priority:
+        updates["priority"] = priority
+    if severity:
+        updates["severity"] = severity
+    if resolution:
+        updates["resolution"] = resolution
+
+    if not updates:
+        raise ToolError("At least one field must be specified")
+
+    try:
+        result = await bz.update_bug(bug_id, updates, comment)
+        return result
+    except Exception as e:
+        raise ToolError(f"Failed to update bug fields\n{e}")
+
+
+@mcp.tool()
+async def add_cc_to_bug(
+    bug_id: int,
+    cc_email: str,
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Add an email address to the CC list of a bug.
+
+    Args:
+        bug_id: Bug ID
+        cc_email: Email address to add to CC list
+    """
+    mcp_log.info(
+        f"[LLM-REQ] add_cc_to_bug(bug_id={bug_id}, cc_email='{cc_email}')"
+    )
+    try:
+        result = await bz.update_bug(bug_id, {"cc": {"add": [cc_email]}}, "")
+        return result
+    except Exception as e:
+        raise ToolError(f"Failed to add CC\n{e}")
+
+
+@mcp.tool()
+async def mark_as_duplicate(
+    bug_id: int,
+    duplicate_of: int,
+    comment: str = "",
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Mark a bug as a duplicate of another bug and close it.
+
+    Args:
+        bug_id: Bug ID to mark as duplicate
+        duplicate_of: Bug ID this is a duplicate of
+        comment: Optional comment (default: auto-generated)
+    """
+    mcp_log.info(
+        f"[LLM-REQ] mark_as_duplicate(bug_id={bug_id}, duplicate_of={duplicate_of})"
+    )
+
+    if not comment:
+        comment = f"Marking as duplicate of bug {duplicate_of}"
+
+    updates = {
+        "status": "CLOSED",
+        "resolution": "DUPLICATE",
+        "dupe_of": duplicate_of
+    }
+
+    try:
+        result = await bz.update_bug(bug_id, updates, comment)
+        return result
+    except Exception as e:
+        raise ToolError(f"Failed to mark as duplicate\n{e}")
+
+
 def disable_components_selectively():
     """
     Disables MCP components based on environment variables.

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -100,3 +100,286 @@ async def test_quicksearch(bz_client):
         assert params["offset"] == "0"
         assert "include_fields" in params
         assert params["include_fields"] == "id,product"
+
+@pytest.mark.asyncio
+async def test_update_bug_single_field(bz_client):
+    """Test updating a single field"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {
+                            "priority": {"removed": "low", "added": "high"}
+                        },
+                        "last_change_time": "2026-03-09T10:00:00Z"
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={"priority": "high"}
+        )
+
+        assert result["bugs"][0]["id"] == 123
+        assert "priority" in result["bugs"][0]["changes"]
+        assert result["bugs"][0]["changes"]["priority"]["added"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_update_bug_multiple_fields(bz_client):
+    """Test updating multiple fields simultaneously"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {
+                            "priority": {"removed": "low", "added": "high"},
+                            "severity": {"removed": "medium", "added": "urgent"},
+                            "status": {"removed": "NEW", "added": "ASSIGNED"}
+                        }
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={
+                "priority": "high",
+                "severity": "urgent",
+                "status": "ASSIGNED"
+            }
+        )
+
+        changes = result["bugs"][0]["changes"]
+        assert len(changes) == 3
+        assert changes["priority"]["added"] == "high"
+        assert changes["severity"]["added"] == "urgent"
+        assert changes["status"]["added"] == "ASSIGNED"
+
+
+@pytest.mark.asyncio
+async def test_update_bug_with_comment(bz_client):
+    """Test bug update with optional comment"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {
+                            "status": {"removed": "NEW", "added": "CLOSED"},
+                            "resolution": {"removed": "", "added": "FIXED"}
+                        }
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={"status": "CLOSED", "resolution": "FIXED"},
+            comment="Fixed in commit abc123"
+        )
+
+        assert result["bugs"][0]["id"] == 123
+        # Verify comment was included in request
+        assert route.called
+        request_body = route.calls.last.request.content
+        assert b"Fixed in commit abc123" in request_body
+
+
+@pytest.mark.asyncio
+async def test_update_bug_close_with_resolution(bz_client):
+    """Test closing a bug with required resolution"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {
+                            "status": {"removed": "ASSIGNED", "added": "CLOSED"},
+                            "resolution": {"removed": "", "added": "FIXED"}
+                        }
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={"status": "CLOSED", "resolution": "FIXED"}
+        )
+
+        changes = result["bugs"][0]["changes"]
+        assert changes["status"]["added"] == "CLOSED"
+        assert changes["resolution"]["added"] == "FIXED"
+
+
+@pytest.mark.asyncio
+async def test_update_bug_duplicate_fields(bz_client):
+    """Test marking bug as duplicate"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {
+                            "status": {"removed": "NEW", "added": "CLOSED"},
+                            "resolution": {"removed": "", "added": "DUPLICATE"},
+                            "dupe_of": {"removed": "", "added": "456"}
+                        }
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={
+                "status": "CLOSED",
+                "resolution": "DUPLICATE",
+                "dupe_of": 456
+            }
+        )
+
+        changes = result["bugs"][0]["changes"]
+        assert changes["resolution"]["added"] == "DUPLICATE"
+        assert changes["dupe_of"]["added"] == "456"
+
+
+@pytest.mark.asyncio
+async def test_update_bug_not_found(bz_client):
+    """Test error handling for non-existent bug"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/999999").mock(
+            return_value=Response(
+                404,
+                json={
+                    "error": True,
+                    "message": "Bug #999999 does not exist.",
+                    "code": 101
+                }
+            )
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await bz_client.update_bug(
+                bug_id=999999,
+                updates={"priority": "high"}
+            )
+
+        assert "404" in str(exc_info.value) or "does not exist" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_permission_denied(bz_client):
+    """Test error handling for insufficient permissions"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                401,
+                json={
+                    "error": True,
+                    "message": "You are not authorized to edit this bug",
+                    "code": 102
+                }
+            )
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await bz_client.update_bug(
+                bug_id=123,
+                updates={"assigned_to": "other@example.com"}
+            )
+
+        assert "401" in str(exc_info.value) or "not authorized" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_validation_error(bz_client):
+    """Test validation error for invalid field combinations"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                400,
+                json={
+                    "error": True,
+                    "message": "You must provide a resolution when status is CLOSED",
+                    "code": 121
+                }
+            )
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await bz_client.update_bug(
+                bug_id=123,
+                updates={"status": "CLOSED"}  # Missing required resolution
+            )
+
+        assert "400" in str(exc_info.value) or "resolution" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_empty_updates(bz_client):
+    """Test behavior with empty updates dictionary"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {}
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={}
+        )
+
+        assert result["bugs"][0]["changes"] == {}
+
+
+@pytest.mark.asyncio
+async def test_update_bug_comment_only(bz_client):
+    """Test adding comment without field updates"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "changes": {}
+                    }]
+                }
+            )
+        )
+
+        result = await bz_client.update_bug(
+            bug_id=123,
+            updates={},
+            comment="Just adding a comment"
+        )
+
+        assert result["bugs"][0]["id"] == 123
+        assert route.called
+        request_body = route.calls.last.request.content
+        assert b"Just adding a comment" in request_body


### PR DESCRIPTION
This commit adds essential write capabilities for managing Bugzilla bugs through the MCP interface, enabling developers to perform common workflow operations without leaving their development environment.

New tools added:

- update_bug_status: Change bug status with proper validation (requires resolution when closing bugs)
- assign_bug: Assign bugs to users with optional comment
- update_bug_fields: Modify priority, severity, and resolution
- add_cc_to_bug: Add email addresses to CC list
- mark_as_duplicate: Properly close bugs as duplicates with both status, resolution, and dupe_of fields

This fills a significant gap in the original implementation, which only supported add_comment for write operations. These additions enable full bug lifecycle management through the MCP interface.

Tested-by: Peter Lemenkov <lemenkov@gmail.com>

Assisted-by: Claude (Anthropic) <https://claude.ai>