### PR TITLE
Enhance bug_info to accept multiple IDs, add bug_history tool, and update quicksearch and bug_info to return the full response envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The `mcp-bugzilla` command supports the following options:
 | `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on |
 | `--api-key-header <HEADER_NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name for the Bugzilla API key |
 | `--use-auth-header` | `USE_AUTH_HEADER` | `False` | Use `Authorization: Bearer` header instead of `api_key` query parameter |
-| `--read-only` | N/A | False | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS`
+| `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
 
 **Note**: Command-line arguments take precedence over environment variables.
 
@@ -211,6 +211,7 @@ export MCP_HOST=127.0.0.1
 export MCP_PORT=8000
 export MCP_API_KEY_HEADER=ApiKey
 export LOG_LEVEL=INFO  # Optional: DEBUG, INFO, WARNING, ERROR, CRITICAL
+export MCP_READ_ONLY=true  # Optional: set to true to disable write operations
 # Selective Disabling Tools (Optional)
 # Works fine in conjunction with --read-only flag
 export MCP_BUGZILLA_DISABLED_METHODS='bug_info,bug_comments'

--- a/README.md
+++ b/README.md
@@ -24,9 +24,18 @@ The server provides the following tools for interacting with Bugzilla:
 
 #### Bug Information
 
-- **`bug_info(id: int)`**: Retrieves comprehensive details for a specified Bugzilla bug ID.
-  - **Returns**: A dictionary containing all available information about the bug (status, assignee, summary, description, attachments, etc.)
-  - **Example**: `bug_info(12345)` returns complete bug details
+- **`bug_info(bug_ids: list[int])`**: Retrieves comprehensive details for specified Bugzilla bug IDs.
+  - **Parameters**:
+    - `bug_ids`: A list of bug IDs to fetch details for
+  - **Returns**: A dictionary containing the array `bugs` which lists all available information about the bugs (status, assignee, summary, description, extensions, etc.)
+  - **Example**: `bug_info([12345, 67890])` returns complete bug details for the specified IDs.
+
+- **`bug_history(id: int, new_since: Optional[datetime] = None)`**: Fetches the history of changes for a given bug ID.
+  - **Parameters**:
+    - `id`: The bug ID to fetch history for
+    - `new_since`: Optional datetime object to only return history entries newer than this time.
+  - **Returns**: A list of history event dictionaries, each containing timestamp, author, and an array of changes.
+  - **Example**: `bug_history(12345, new_since=datetime.fromisoformat("2026-01-01T00:00:00"))` returns all history changes newer than Jan 1, 2026.
 
 - **`bug_comments(id: int, include_private_comments: bool = False, new_since: Optional[datetime] = None)`**: Fetches all comments associated with a given bug ID.
   - **Parameters**:
@@ -34,7 +43,9 @@ The server provides the following tools for interacting with Bugzilla:
     - `include_private_comments`: Whether to include private comments (default: `False`)
     - `new_since`: Optional datetime object to only return comments newer than this time.
   - **Returns**: A list of comment dictionaries, each containing author, timestamp, text, and privacy status
-  - **Example**: `bug_comments(12345, include_private_comments=True, new_since=datetime.fromisoformat("2024-01-01T00:00:00"))` returns all comments newer than Jan 1, 2024 including private ones
+  - **Example**: `bug_comments(12345, include_private_comments=True, new_since=datetime.fromisoformat("2026-01-01T00:00:00"))` returns all comments newer than Jan 1, 2026 including private ones
+
+
 
 - **`add_comment(bug_id: int, comment: str, is_private: bool = False)`**: Adds a new comment to a specified bug.
   - **Parameters**:
@@ -356,7 +367,7 @@ Set the log level using the `LOG_LEVEL` environment variable:
 
 ```python
 # MCP client call
-result = client.call_tool("bug_info", {"id": 12345})
+result = client.call_tool("bug_info", {"bug_ids": [12345]})
 print(result)
 # Returns complete bug details including status, assignee, summary, etc.
 ```
@@ -384,9 +395,15 @@ result = client.call_tool("add_comment", {
 # Returns: {"id": 67890} - the new comment ID
 ```
 
-### Example 4: Get Bug Comments
+### Example 4: Get Bug History and Comments
 
 ```python
+# Get the history of changes for a bug
+history = client.call_tool("bug_history", {
+    "id": 12345,
+    "new_since": datetime.fromisoformat("2026-01-01T00:00:00")
+})
+
 # Get all public comments
 public_comments = client.call_tool("bug_comments", {
     "id": 12345,

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ The server provides the following tools for interacting with Bugzilla:
 - **`bug_url(bug_id: int)`**: Constructs and returns the direct URL to a specific bug on the Bugzilla server.
   - **Returns**: A string representing the bug's URL (e.g., `"https://bugzilla.example.com/show_bug.cgi?id=12345"`)
 
-- **`server_url_resource()`**: Returns the base URL of the configured Bugzilla server.
-  - **Returns**: A string representing the base URL.
+- **`bugzilla_server_info()`**: Returns comprehensive Bugzilla server information.
+  - **Returns**: A dictionary containing `url`, `version`, `extensions`, `timezone`, `time`, and `parameters`.
 
 - **`mcp_server_info_resource()`**: Returns the configuration arguments being used by the current server instance (version, host, port, etc.).
   - **Returns**: A dictionary containing server configuration.

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -46,7 +46,8 @@ def main():
     parser.add_argument(
         "--read-only",
         action="store_true",
-        help="Disables all methods which modify the state of the bug",
+        default=os.getenv("MCP_READ_ONLY", "false").lower() == "true",
+        help="Disables all methods which modify the state of the bug. Environment variable MCP_READ_ONLY=true can also be used.",
     )
     args = parser.parse_args()
 

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -103,15 +103,16 @@ class Bugzilla:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise
 
-    async def bug_info(self, bug_id: int) -> dict[str, Any]:
-        """Get information about a given bug"""
-        # Note: self.client has base_url set to .../rest
-        # So we request /bug/{id} relative to that.
-        url = f"/bug/{bug_id}"
-        mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url}")
+    async def bug_info(self, ids: list[int]) -> dict[str, Any]:
+        """Get information about a given bug or list of bugs"""
+
+        url = "/bug"
+        params = {"id": ",".join(str(i) for i in ids)}
+
+        mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url} params={params}")
 
         try:
-            r = await self.client.get(url)
+            r = await self.client.get(url, params=params)
             r.raise_for_status()
         except httpx.HTTPStatusError as e:
             mcp_log.error(
@@ -122,10 +123,40 @@ class Bugzilla:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise
 
-        data = r.json().get("bugs", [{}])[0]
-        mcp_log.info(f"[BZ-RES] Found bug {bug_id}")
-        mcp_log.debug(f"[BZ-RES] {data}")
-        return data
+        envelope = r.json()
+        bugs = envelope.get("bugs", [])
+        mcp_log.info(f"[BZ-RES] Retrieved {len(bugs)} bugs")
+        mcp_log.debug(f"[BZ-RES] {envelope}")
+        return envelope
+
+    async def bug_history(
+        self, bug_id: int, new_since: Optional[datetime] = None
+    ) -> list[dict[str, Any]]:
+        """Get history of a bug"""
+        url = f"/bug/{bug_id}/history"
+        params = {}
+        if new_since:
+            params["new_since"] = new_since.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url} params={params}")
+
+        try:
+            r = await self.client.get(url, params=params)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        data = r.json().get("bugs", [])
+        history = data[0].get("history", []) if data else []
+        mcp_log.info(f"[BZ-RES] Found {len(history)} history items")
+        mcp_log.debug(f"[BZ-RES] {history}")
+        return history
 
     async def bug_comments(
         self, bug_id: int, new_since: Optional[datetime] = None
@@ -183,7 +214,7 @@ class Bugzilla:
 
     async def quicksearch(
         self, query: str, status: str, include_fields: str, limit: int, offset: int
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Perform a quicksearch"""
         # Quicksearch isn't a direct REST endpoint usually, but /bug with quicksearch param works
 
@@ -209,9 +240,10 @@ class Bugzilla:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise
 
-        bugs = r.json().get("bugs", [])
+        envelope = r.json()
+        bugs = envelope.get("bugs", [])
         mcp_log.info(f"[BZ-RES] Found {len(bugs)} bugs")
-        return bugs
+        return envelope
 
     async def update_bug(
         self, bug_id: int, updates: dict[str, Any], comment: str = ""

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -147,11 +147,11 @@ class Bugzilla:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise
 
-    async def bug_info(self, ids: list[int]) -> dict[str, Any]:
+    async def bug_info(self, ids: set[int]) -> dict[str, Any]:
         """Get information about a given bug or list of bugs"""
 
         if len(ids) == 1:
-            url = f"/bug/{ids[0]}"
+            url = f"/bug/{next(iter(ids))}"
             params = {}
         else:
             url = "/bug"

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -150,8 +150,12 @@ class Bugzilla:
     async def bug_info(self, ids: list[int]) -> dict[str, Any]:
         """Get information about a given bug or list of bugs"""
 
-        url = "/bug"
-        params = {"id": ",".join(str(i) for i in ids)}
+        if len(ids) == 1:
+            url = f"/bug/{ids[0]}"
+            params = {}
+        else:
+            url = "/bug"
+            params = {"id": ",".join(str(i) for i in ids)}
 
         mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url} params={params}")
 

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -6,6 +6,7 @@ Author: Sai Karthik <kskarthik@disroot.org>
 License: Apache 2.0
 """
 
+import asyncio
 import logging
 import os
 from datetime import datetime
@@ -99,6 +100,49 @@ class Bugzilla:
             )
             raise
 
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+    async def bugzilla_info(self) -> dict[str, Any]:
+        """Fetch comprehensive bugzilla server information:
+        it returns url, version, extensions, timezone, time and parameters for the current user in a dictionary
+        """
+        try:
+            # Fetch everything concurrently
+            version_r, extensions_r, time_r, parameters_r = await asyncio.gather(
+                self.client.get("/version"),
+                self.client.get("/extensions"),
+                self.client.get("/time"),
+                self.client.get("/parameters"),
+            )
+
+            # Raise for status on all
+            for r in [version_r, extensions_r, time_r, parameters_r]:
+                r.raise_for_status()
+
+            # Combine results
+            version_data = version_r.json()
+            extensions_data = extensions_r.json()
+            time_data = time_r.json()
+            parameters_data = parameters_r.json()
+
+            result = {
+                "url": self.base_url,
+                "version": version_data.get("version"),
+                "extensions": extensions_data.get("extensions", {}),
+                "timezone": time_data.get("tz_name"),
+                "time": time_data.get("web_time"),
+                "parameters": parameters_data.get("parameters", {}),
+            }
+            mcp_log.info(f"[BZ-RES] Retrieved bugzilla server info from {self.base_url}")
+            return result
+
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
         except httpx.RequestError as e:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -464,4 +464,4 @@ def start():
 
     mcp_log.info(f"Starting Bugzilla MCP server on {cli_args.host}:{cli_args.port}")
 
-    mcp.run(transport="http", host=cli_args.host, port=cli_args.port)
+    mcp.run(transport="http", host=cli_args.host, port=cli_args.port, show_banner=False)

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -52,17 +52,39 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
 
 
 @mcp.tool()
-async def bug_info(id: int, bz: Bugzilla = Depends(get_bz)) -> dict[str, Any]:
-    """Returns the entire information about a given bugzilla bug id"""
+async def bug_info(
+    bug_ids: list[int],
+    bz: Bugzilla = Depends(get_bz)
+) -> dict[str, Any]:
+    """Returns the entire information for one or more bugzilla bug ids."""
 
-    mcp_log.info(f"[LLM-REQ] bug_info(id={id})")
+    mcp_log.info(f"[LLM-REQ] bug_info(ids={bug_ids})")
 
     try:
-        result = await bz.bug_info(id)
+        result = await bz.bug_info(bug_ids)
         return result
 
     except Exception as e:
         raise ToolError(f"Failed to fetch bug info\nReason: {e}")
+
+@mcp.tool()
+async def bug_history(
+    id: int,
+    new_since: Optional[datetime] = None,
+    bz: Bugzilla = Depends(get_bz),
+) -> list[dict[str, Any]]:
+    """Returns the history of given bug id.
+    new_since allows filtering history newer than the given date.
+    """
+
+    mcp_log.info(f"[LLM-REQ] bug_history(id={id}, new_since={new_since})")
+
+    try:
+        history = await bz.bug_history(id, new_since=new_since)
+        mcp_log.info(f"[LLM-RES] Returning {len(history)} history items")
+        return history
+    except Exception as e:
+        raise ToolError(f"Failed to fetch bug history\nReason: {e}")
 
 
 @mcp.tool()
@@ -124,11 +146,12 @@ async def bugs_quicksearch(
     limit: Optional[int] = 50,
     offset: Optional[int] = 0,
     bz: Bugzilla = Depends(get_bz),
-) -> List[Any]:
+) -> dict[str, Any]:
     """Search bugs using bugzilla's quicksearch syntax
 
     To reduce the token limit & response time, only returns a subset of fields for each bug
     The user can query full details of each bug using the bug_info tool
+    Returns the top-level bug data envelope containing the matched bugs.
     """
 
     mcp_log.info(
@@ -137,10 +160,10 @@ async def bugs_quicksearch(
 
     try:
         # We moved quicksearch logic to mcp_utils
-        bugs = await bz.quicksearch(query, status, include_fields, limit, offset)
+        envelope = await bz.quicksearch(query, status, include_fields, limit, offset)
 
-        mcp_log.info(f"[LLM-RES] Found {len(bugs)} bugs")
-        return bugs
+        mcp_log.info(f"[LLM-RES] Returning quicksearch envelope")
+        return envelope
 
     except Exception as e:
         raise ToolError(f"Search failed: {e}")

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -56,7 +56,7 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
 
 @mcp.tool()
 async def bug_info(
-    bug_ids: list[int],
+    bug_ids: set[int],
     bz: Bugzilla = Depends(get_bz)
 ) -> dict[str, Any]:
     """Returns the entire information for one or more bugzilla bug ids."""

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -195,10 +195,13 @@ async def quicksearch_syntax_resource(bz: Bugzilla = Depends(get_bz)) -> str:
 
 
 @mcp.tool()
-def server_url_resource() -> str:
-    """bugzilla server's base url"""
-    mcp_log.info("[LLM-REQ] server_url_resource()")
-    return base_url
+async def bugzilla_server_info(bz: Bugzilla = Depends(get_bz)) -> dict[str, Any]:
+    """Returns comprehensive bugzilla server information (url, version, extensions, timezone, time, parameters)."""
+    mcp_log.info("[LLM-REQ] bugzilla_server_info()")
+    try:
+        return await bz.bugzilla_info()
+    except Exception as e:
+        raise ToolError(f"Failed to fetch bugzilla server info\nReason: {e}")
 
 
 @mcp.tool()

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -27,6 +27,9 @@ cli_args: Namespace
 # Global variable to hold the base_url, set by the start() function
 base_url: str = ""
 
+# Global variable for read-only mode
+read_only: bool = False
+
 
 @asynccontextmanager
 async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
@@ -438,7 +441,7 @@ def disable_write_components():
     Disable all components which alter the state of bug
     Invoked when --read-only flag is set
     """
-    if getattr(cli_args, "read_only", False):
+    if read_only:
         mcp_log.info("Disabling all components which can modify bugs")
         # disable all methods with write tags
         mcp.disable(tags={"write"})
@@ -448,8 +451,9 @@ def start():
     """
     Starts the FastMCP server for Bugzilla.
     """
-    global base_url
+    global base_url, read_only
     base_url = cli_args.bugzilla_server
+    read_only = getattr(cli_args, "read_only", False)
     # Ensure base_url doesn't have trailing slash for consistency
     if base_url.endswith("/"):
         base_url = base_url[:-1]

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -44,18 +44,25 @@ async def test_bugzilla_info(bz_client):
 
 
 @pytest.mark.asyncio
-async def test_bug_info(bz_client):
+async def test_bug_info_single(bz_client):
+    """Test fetching info for a single bug ID"""
     async with respx.mock(base_url=MOCK_URL) as respx_mock:
-        # Note: Bugzilla client appends /rest to the base url passed in constructor
-        # and then requests /bug/{id} relative to that.
-        # But the bugzilla client sets base_url of httpx client to .../rest
-        # So we should match against the full URL or careful with defaults.
-        # Given the implementation: self.client = httpx.AsyncClient(base_url=self.api_url, ...)
-        # where self.api_url = url + "/rest"
-        # The request is client.get(f"/bug/{bug_id}") which resolves to {url}/rest/bug/{bug_id}
+        route_bug = respx_mock.get("/rest/bug/123").mock(
+            return_value=Response(
+                200, json={"bugs": [{"id": 123, "summary": "Single Test Bug"}]}
+            )
+        )
 
-        # respx mocks verify the full URL usually.
+        bug_env = await bz_client.bug_info({123})
+        assert len(bug_env["bugs"]) == 1
+        assert bug_env["bugs"][0]["id"] == 123
+        assert bug_env["bugs"][0]["summary"] == "Single Test Bug"
+        assert route_bug.called
 
+@pytest.mark.asyncio
+async def test_bug_info_multiple(bz_client):
+    """Test fetching info for multiple bug IDs"""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
         route_bug = respx_mock.get("/rest/bug").mock(
             return_value=Response(
                 200, json={"bugs": [
@@ -65,15 +72,13 @@ async def test_bug_info(bz_client):
             )
         )
 
-        bug_env = await bz_client.bug_info([123, 456])
-        assert bug_env["bugs"][0]["id"] == 123
-        assert bug_env["bugs"][0]["summary"] == "Test Bug"
-        
-        assert bug_env["bugs"][1]["id"] == 456
-        assert bug_env["bugs"][1]["summary"] == "Another Bug"
+        bug_env = await bz_client.bug_info({123, 456})
+        assert any(b["id"] == 123 for b in bug_env["bugs"])
+        assert any(b["id"] == 456 for b in bug_env["bugs"])
 
         assert route_bug.called
-        assert route_bug.calls.last.request.url.params["id"] == "123,456"
+        id_param = route_bug.calls.last.request.url.params["id"]
+        assert set(id_param.split(",")) == {"123", "456"}
 
 @pytest.mark.asyncio
 async def test_bug_history(bz_client):

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -29,15 +29,52 @@ async def test_bug_info(bz_client):
 
         # respx mocks verify the full URL usually.
 
-        respx_mock.get("/rest/bug/123").mock(
+        route_bug = respx_mock.get("/rest/bug").mock(
             return_value=Response(
-                200, json={"bugs": [{"id": 123, "summary": "Test Bug"}]}
+                200, json={"bugs": [
+                    {"id": 123, "summary": "Test Bug"},
+                    {"id": 456, "summary": "Another Bug"}
+                ]}
             )
         )
 
-        bug = await bz_client.bug_info(123)
-        assert bug["id"] == 123
-        assert bug["summary"] == "Test Bug"
+        bug_env = await bz_client.bug_info([123, 456])
+        assert bug_env["bugs"][0]["id"] == 123
+        assert bug_env["bugs"][0]["summary"] == "Test Bug"
+        
+        assert bug_env["bugs"][1]["id"] == 456
+        assert bug_env["bugs"][1]["summary"] == "Another Bug"
+
+        assert route_bug.called
+        assert route_bug.calls.last.request.url.params["id"] == "123,456"
+
+@pytest.mark.asyncio
+async def test_bug_history(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.get("/rest/bug/123/history").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [{
+                        "id": 123,
+                        "history": [
+                            {"when": "2026-03-09T10:00:00Z", "who": "user@example.com"}
+                        ]
+                    }]
+                }
+            )
+        )
+
+        history = await bz_client.bug_history(123)
+        assert len(history) == 1
+        assert history[0]["when"] == "2026-03-09T10:00:00Z"
+        assert route.called
+        assert "new_since" not in route.calls.last.request.url.params
+
+        test_dt = datetime(2026, 3, 9, 0, 0, 0)
+        history_with_since = await bz_client.bug_history(123, new_since=test_dt)
+        assert len(history_with_since) == 1
+        assert route.calls.last.request.url.params["new_since"] == "2026-03-09T00:00:00Z"
 
 
 @pytest.mark.asyncio
@@ -95,10 +132,10 @@ async def test_quicksearch(bz_client):
         )
 
         # Test with explicit arguments (mandatory in mcp_utils)
-        bugs = await bz_client.quicksearch(
+        search_env = await bz_client.quicksearch(
             "product:Foo", status="ALL", include_fields="id,product", limit=50, offset=0
         )
-        assert len(bugs) == 2
+        assert len(search_env["bugs"]) == 2
 
         # Verify call arguments
         assert route.called
@@ -391,3 +428,7 @@ async def test_update_bug_comment_only(bz_client):
         assert route.called
         request_body = route.calls.last.request.content
         assert b"Just adding a comment" in request_body
+
+
+
+

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -17,6 +17,33 @@ async def bz_client():
 
 
 @pytest.mark.asyncio
+async def test_bugzilla_info(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.get("/rest/version").mock(
+            return_value=Response(200, json={"version": "5.0.4"})
+        )
+        respx_mock.get("/rest/extensions").mock(
+            return_value=Response(200, json={"extensions": {"MockExtension": {}}})
+        )
+        respx_mock.get("/rest/time").mock(
+            return_value=Response(
+                200, json={"tz_name": "UTC", "web_time": "2026-03-18T10:00:00Z"}
+            )
+        )
+        respx_mock.get("/rest/parameters").mock(
+            return_value=Response(200, json={"parameters": {"urlbase": "http://mock"}})
+        )
+
+        info = await bz_client.bugzilla_info()
+        assert info["url"] == MOCK_URL.rstrip("/rest")
+        assert info["version"] == "5.0.4"
+        assert "MockExtension" in info["extensions"]
+        assert info["timezone"] == "UTC"
+        assert info["time"] == "2026-03-18T10:00:00Z"
+        assert info["parameters"]["urlbase"] == "http://mock"
+
+
+@pytest.mark.asyncio
 async def test_bug_info(bz_client):
     async with respx.mock(base_url=MOCK_URL) as respx_mock:
         # Note: Bugzilla client appends /rest to the base url passed in constructor


### PR DESCRIPTION
1. Enhance _bug_info_ to accept multiple IDs
2. _bug_history_ tool added
3. update _quicksearch_ and _bug_info_ to return the full response envelope
4. Former _server_url_resource_ migrated to _bugzilla_server_info_, collecting more infos from the BZ instance
5. Added MCP_READ_ONLY, dual of --read-only param, facilitating the usage with containers 