### PR TITLE
fix: clear resolution when reopening bugs

### DIFF
--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -294,6 +294,9 @@ async def update_bug_status(
     updates = {"status": status}
     if resolution:
         updates["resolution"] = resolution
+    elif status not in ("CLOSED", "VERIFIED"):
+        # Clear resolution when reopening
+        updates["resolution"] = ""
 
     # Validate: CLOSED requires resolution
     if status == "CLOSED" and not resolution:


### PR DESCRIPTION
## Problem

`update_bug_status` could not reopen bugs that were in CLOSED or VERIFIED state. The Bugzilla REST API requires `resolution` to be explicitly set to `""` when transitioning away from these states, otherwise the API rejects the request.

## Testing

Tested on Red Hat Bugzilla — successfully reopened bug [2365595](https://bugzilla.redhat.com/show_bug.cgi?id=2365595) from CLOSED/NOTABUG back to NEW with resolution automatically cleared.