### PR TITLE
feat: add stdio transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [Unreleased]
+
+### Added
+- add stdio transport (`--transport stdio`, `BUGZILLA_API_KEY` / `--api-key` for auth)
+- remove uv from dev dependencies (redundant)
+
+### Fixed
+- Upgrade GitHub Actions and improve test job configuration
+- set minimum python version only instead of pinning
+- rename CI job to fit the action
+
 ## [v0.13.1] - 2026-06-01
 
 ### Fixed
@@ -76,7 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - `update_bug_fields`: Modify priority, severity, and resolution
   - `add_cc_to_bug`: Add email addresses to CC list
   - `mark_as_duplicate`: Properly close bugs as duplicates with both status, resolution, and dupe_of fields
-- Add `--read-only` CLI flag to disable tools which can modify status of a bug
+  - Add `--read-only` CLI flag to disable tools which can modify status of a bug
 
 ### Fixed
 - Add missing CLI flag `--use-auth-header`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 - add stdio transport (`--transport stdio`, `BUGZILLA_API_KEY` / `--api-key` for auth)
+- warn at startup when `--api-key` / `BUGZILLA_API_KEY` is set with `--transport http` (the key is ignored in http mode; clients send it per-request)
 - remove uv from dev dependencies (redundant)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,11 +200,15 @@ The `mcp-bugzilla` command supports the following options:
 | Argument | Environment Variable | Default | Description |
 |----------|---------------------|---------|-------------|
 | `--bugzilla-server <URL>` | `BUGZILLA_SERVER` | *Required* | Base URL of the Bugzilla server (e.g., `https://bugzilla.example.com`) |
-| `--host <ADDRESS>` | `MCP_HOST` | `127.0.0.1` | Host address for the MCP server to listen on |
-| `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on |
-| `--api-key-header <HEADER_NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name for the Bugzilla API key |
+| `--transport {http,stdio}` | `MCP_TRANSPORT` | `http` | Transport for the MCP server. `stdio` is for direct subprocess launches by an MCP client; `http` exposes a network endpoint |
+| `--host <ADDRESS>` | `MCP_HOST` | `127.0.0.1` | Host address for the MCP server to listen on (http transport only) |
+| `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on (http transport only) |
+| `--api-key <KEY>` | `BUGZILLA_API_KEY` | *Required for stdio* | Bugzilla API key. Required with `--transport stdio` (no HTTP headers exist there). Ignored for `--transport http`, where clients send the key per-request via the API key header |
+| `--api-key-header <HEADER_NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name for the Bugzilla API key (http transport only) |
 | `--use-auth-header` | `USE_AUTH_HEADER` | `False` | Use `Authorization: Bearer` header instead of `api_key` query parameter |
 | `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
+
+**Note**: `--host` and `--port` are rejected with an error when used together with `--transport stdio`.
 
 **Note**: Command-line arguments take precedence over environment variables.
 
@@ -244,6 +248,17 @@ mcp-bugzilla --bugzilla-server https://bugzilla.opensuse.org
 ```
 
 The server will start listening on `http://127.0.0.1:8000/mcp/` by default.
+
+#### Stdio transport
+
+For MCP clients that launch the server as a subprocess and speak over stdin/stdout (e.g. Claude Desktop-style configs), use `--transport stdio`. Because there is no per-request HTTP scope, the Bugzilla API key must be provided up front via `BUGZILLA_API_KEY` or `--api-key`:
+
+```bash
+BUGZILLA_API_KEY=your_api_key \
+  mcp-bugzilla --bugzilla-server https://bugzilla.opensuse.org --transport stdio
+```
+
+`--host` and `--port` are not valid in stdio mode and will cause the server to exit with an error.
 
 ### Endpoint
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "uv",
     "pytest",
     "pytest-asyncio",
     "respx",

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -49,6 +49,21 @@ def main():
         default=os.getenv("MCP_READ_ONLY", "false").lower() == "true",
         help="Disables all methods which modify the state of the bug. Environment variable MCP_READ_ONLY=true can also be used.",
     )
+
+    parser.add_argument(
+        "--transport",
+        type=str,
+        choices=["http", "stdio"],
+        default=os.getenv("MCP_TRANSPORT", "http"),
+        help="Transport for the MCP server: 'http' (default) or 'stdio'. Environment variable MCP_TRANSPORT can also be used.",
+    )
+
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=os.getenv("BUGZILLA_API_KEY"),
+        help="Bugzilla API key. Required for --transport stdio (no HTTP headers exist there). Environment variable BUGZILLA_API_KEY can also be used. Ignored for --transport http (clients send the key per-request via the API key header).",
+    )
     args = parser.parse_args()
 
     # The default behavior of argparse with os.getenv already handles the priority:
@@ -59,6 +74,25 @@ def main():
             "Error: --bugzilla-server argument or BUGZILLA_SERVER environment variable must be set. Exiting."
         )
         sys.exit(1)
+
+    # Stdio transport has no HTTP request scope, so --host/--port are meaningless
+    # and the API key must be provided up-front (env var or CLI flag).
+    # We sniff sys.argv because argparse can't natively tell a default value from
+    # an explicit pass (env-var defaults muddy the comparison further).
+    if args.transport == "stdio":
+        explicit_host_or_port = any(
+            tok == "--host"
+            or tok == "--port"
+            or tok.startswith("--host=")
+            or tok.startswith("--port=")
+            for tok in sys.argv[1:]
+        )
+        if explicit_host_or_port:
+            parser.error("--host/--port are not valid with --transport stdio")
+        if not args.api_key:
+            parser.error(
+                "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
+            )
 
     server.cli_args = args
     server.start()

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -93,6 +93,15 @@ def main():
             parser.error(
                 "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
             )
+    elif args.transport == "http" and args.api_key:
+        # In http mode the server takes the API key from each client's per-request
+        # header; the startup-time --api-key / BUGZILLA_API_KEY is unused. Warn so
+        # the user cleans the config and doesn't think they're authenticating.
+        mcp_log.warning(
+            "--api-key / BUGZILLA_API_KEY is set but ignored with --transport http "
+            "(clients send the key per-request via the API key header). "
+            "Unset it to clean the config."
+        )
 
     server.cli_args = args
     server.start()

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -33,14 +33,28 @@ read_only: bool = False
 
 @asynccontextmanager
 async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
-    """Dependency to get the current Bugzilla client"""
+    """Dependency to get the current Bugzilla client.
+
+    For http transport, the API key is read per-request from the configured header.
+    For stdio transport, there is no HTTP request scope, so the key comes from
+    the CLI flag / BUGZILLA_API_KEY env var captured at startup.
+    """
     mcp_log.debug("api_key: Checking")
 
-    api_key_header = getattr(cli_args, "api_key_header", "ApiKey")
-    api_key_value = headers.get(api_key_header.lower())
+    transport = getattr(cli_args, "transport", "http")
 
-    if not api_key_value:
-        raise ValidationError(f"`{api_key_header}` header is required")
+    if transport == "stdio":
+        api_key_value = getattr(cli_args, "api_key", None)
+        if not api_key_value:
+            # Defense in depth; main() already validates this at startup.
+            raise ValidationError(
+                "stdio transport requires --api-key or BUGZILLA_API_KEY env var"
+            )
+    else:
+        api_key_header = getattr(cli_args, "api_key_header", "ApiKey")
+        api_key_value = headers.get(api_key_header.lower())
+        if not api_key_value:
+            raise ValidationError(f"`{api_key_header}` header is required")
 
     mcp_log.debug("api_key: Found")
     bz = Bugzilla(
@@ -556,6 +570,16 @@ def start():
     disable_components_selectively()
     disable_write_components()
 
-    mcp_log.info(f"Starting Bugzilla MCP server on {cli_args.host}:{cli_args.port}")
+    transport = getattr(cli_args, "transport", "http")
 
-    mcp.run(transport="http", host=cli_args.host, port=cli_args.port, show_banner=False)
+    if transport == "stdio":
+        mcp_log.info("Starting Bugzilla MCP server on stdio")
+        mcp.run(transport="stdio", show_banner=False)
+    else:
+        mcp_log.info(f"Starting Bugzilla MCP server on {cli_args.host}:{cli_args.port}")
+        mcp.run(
+            transport="http",
+            host=cli_args.host,
+            port=cli_args.port,
+            show_banner=False,
+        )

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -572,14 +572,12 @@ def start():
 
     transport = getattr(cli_args, "transport", "http")
 
-    if transport == "stdio":
-        mcp_log.info("Starting Bugzilla MCP server on stdio")
-        mcp.run(transport="stdio", show_banner=False)
-    else:
+    run_kwargs = {"show_banner": False, "transport": transport}
+
+    if transport != "stdio":
+        run_kwargs.update({"host": cli_args.host, "port": cli_args.port})
         mcp_log.info(f"Starting Bugzilla MCP server on {cli_args.host}:{cli_args.port}")
-        mcp.run(
-            transport="http",
-            host=cli_args.host,
-            port=cli_args.port,
-            show_banner=False,
-        )
+    else:
+        mcp_log.info("Starting Bugzilla MCP server on stdio")
+
+    mcp.run(**run_kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,148 @@
+"""Tests for CLI argument validation in mcp_bugzilla.main()."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from mcp_bugzilla import main
+
+
+@pytest.fixture
+def captured_mcp_log(caplog):
+    """Attach caplog's handler to the bugzilla-mcp logger.
+
+    The mcp_log logger has propagate=False (see mcp_utils.py), so caplog's
+    default root-level capture does not see its records. We add caplog.handler
+    directly for the duration of the test.
+    """
+    logger = logging.getLogger("bugzilla-mcp")
+    logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger="bugzilla-mcp")
+    try:
+        yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def _run_main(monkeypatch, argv, env=None):
+    """Run main() with patched argv/env and a no-op server.start()."""
+    monkeypatch.setattr("sys.argv", ["mcp-bugzilla", *argv])
+    # Clear env vars that argparse defaults read from, then apply test-specific ones.
+    for var in (
+        "BUGZILLA_SERVER",
+        "BUGZILLA_API_KEY",
+        "MCP_HOST",
+        "MCP_PORT",
+        "MCP_TRANSPORT",
+        "MCP_READ_ONLY",
+        "MCP_API_KEY_HEADER",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    with patch("mcp_bugzilla.server.start") as mock_start:
+        main()
+    return mock_start
+
+
+def test_http_transport_with_api_key_warns_but_starts(monkeypatch, captured_mcp_log):
+    mock_start = _run_main(
+        monkeypatch,
+        [
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "http",
+            "--api-key",
+            "leftover-key",
+        ],
+    )
+    mock_start.assert_called_once()
+    warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
+    assert any("ignored with --transport http" in r.message for r in warnings), (
+        f"Expected http+api_key warning, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_http_transport_without_api_key_does_not_warn(monkeypatch, captured_mcp_log):
+    mock_start = _run_main(
+        monkeypatch,
+        [
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "http",
+        ],
+    )
+    mock_start.assert_called_once()
+    warnings = [
+        r
+        for r in captured_mcp_log.records
+        if r.levelno == logging.WARNING and "ignored with --transport http" in r.message
+    ]
+    assert warnings == [], (
+        f"Did not expect a warning, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_http_transport_with_env_api_key_warns(monkeypatch, captured_mcp_log):
+    """The warning must also fire when api_key comes from BUGZILLA_API_KEY env var."""
+    mock_start = _run_main(
+        monkeypatch,
+        [
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "http",
+        ],
+        env={"BUGZILLA_API_KEY": "from-env"},
+    )
+    mock_start.assert_called_once()
+    warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
+    assert any("ignored with --transport http" in r.message for r in warnings), (
+        f"Expected http+api_key warning, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_stdio_transport_with_api_key_does_not_warn(monkeypatch, captured_mcp_log):
+    mock_start = _run_main(
+        monkeypatch,
+        [
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "stdio",
+            "--api-key",
+            "k",
+        ],
+    )
+    mock_start.assert_called_once()
+    warnings = [
+        r
+        for r in captured_mcp_log.records
+        if r.levelno == logging.WARNING and "ignored with --transport http" in r.message
+    ]
+    assert warnings == [], (
+        f"Did not expect http warning in stdio mode, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_stdio_transport_without_api_key_exits(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "mcp-bugzilla",
+            "--bugzilla-server",
+            "https://bugzilla.example.com",
+            "--transport",
+            "stdio",
+        ],
+    )
+    for var in ("BUGZILLA_API_KEY", "MCP_TRANSPORT"):
+        monkeypatch.delenv(var, raising=False)
+
+    with patch("mcp_bugzilla.server.start") as mock_start, pytest.raises(SystemExit):
+        main()
+    mock_start.assert_not_called()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,72 @@
+"""Tests for transport selection and per-transport API key sourcing."""
+
+from argparse import Namespace
+from unittest.mock import patch
+
+import pytest
+
+from mcp_bugzilla import server
+
+
+def _base_args(**overrides):
+    """Build a Namespace with all attrs server.start() / get_bz() may read."""
+    defaults = dict(
+        bugzilla_server="https://bugzilla.example.com",
+        host="127.0.0.1",
+        port=8000,
+        api_key_header="ApiKey",
+        use_auth_header=False,
+        read_only=False,
+        transport="http",
+        api_key=None,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_stdio_transport_invokes_mcp_run_stdio():
+    server.cli_args = _base_args(transport="stdio", api_key="k")
+    with patch.object(server.mcp, "run") as mock_run:
+        server.start()
+    mock_run.assert_called_once_with(transport="stdio", show_banner=False)
+
+
+def test_http_transport_unchanged():
+    server.cli_args = _base_args(transport="http")
+    with patch.object(server.mcp, "run") as mock_run:
+        server.start()
+    mock_run.assert_called_once_with(
+        transport="http", host="127.0.0.1", port=8000, show_banner=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_bz_uses_cli_api_key_in_stdio_mode():
+    server.cli_args = _base_args(transport="stdio", api_key="from-cli")
+    # Set base_url the way start() would; we skip start() to avoid mcp.run().
+    server.base_url = "https://bugzilla.example.com"
+
+    # In stdio mode, headers are irrelevant; pass an empty dict.
+    async with server.get_bz(headers={}) as bz:
+        assert bz.api_key == "from-cli"
+
+
+@pytest.mark.asyncio
+async def test_get_bz_uses_header_in_http_mode():
+    server.cli_args = _base_args(transport="http")
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={"apikey": "from-header"}) as bz:
+        assert bz.api_key == "from-header"
+
+
+@pytest.mark.asyncio
+async def test_get_bz_raises_in_stdio_mode_without_key():
+    from fastmcp.exceptions import ValidationError
+
+    server.cli_args = _base_args(transport="stdio", api_key=None)
+    server.base_url = "https://bugzilla.example.com"
+
+    with pytest.raises(ValidationError):
+        async with server.get_bz(headers={}):
+            pass

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "respx" },
-    { name = "uv" },
 ]
 
 [package.metadata]
@@ -665,7 +664,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "respx", marker = "extra == 'dev'" },
-    { name = "uv", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
 
@@ -1212,32 +1210,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
-]
-
-[[package]]
-name = "uv"
-version = "0.11.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/ea/c25007a2964e5f5f5300db2cab16fe8c2fc1284f0b9bea6212e06097d05b/uv-0.11.18.tar.gz", hash = "sha256:61f2bc99898383f9bf04e24b984e42e19cde378dd79192935ca21d75563368a8", size = 4209283, upload-time = "2026-06-01T19:43:07.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/f1/692f05ecffe73a8bbf62c19ed3ed897556c1a4b00a7b2dd18e5b73f92daa/uv-0.11.18-py3-none-linux_armv6l.whl", hash = "sha256:b35d25a5fda7d058b1684476a47555afbe0e9560318c7a8f72cccc6b77b42e1a", size = 23592196, upload-time = "2026-06-01T19:42:27.089Z" },
-    { url = "https://files.pythonhosted.org/packages/38/ad/57a31ea9ffc53a2fb5cd9a60b5edb9e4df7c526ba80be4517c6d73cf4fa7/uv-0.11.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:90685bda9e15600ae9a2a10c326008a69f28d8652555a2e760e1493e4b1ae7b5", size = 23193111, upload-time = "2026-06-01T19:42:52.293Z" },
-    { url = "https://files.pythonhosted.org/packages/af/3b/130515418bdd4be1aec5941ca2fa53dc0281750434e835ff633e6f8cd944/uv-0.11.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0571ec649f25e2cca9eb994637aa1ae27ab3db58f87c5a9b5f9776d5d7cd2298", size = 21621552, upload-time = "2026-06-01T19:42:49.709Z" },
-    { url = "https://files.pythonhosted.org/packages/95/de/7dccc8c8449235172e872a9b13b03a67e4f7975ffb875da70a3eada8a4f6/uv-0.11.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5df2b2a59f1ee4392066df24ef9904b3bbdc226e8ab9bdff8e290127fcddc3a3", size = 23456077, upload-time = "2026-06-01T19:43:00.595Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/26/7490fc8a7b56847ce4aabcb40b0a938f4daf79fd7bd3a8f3a6d6babe00cc/uv-0.11.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:351db8ef413055b7e8e894ff54f30ce3fd001f4f3bbae66c2f519f30008fa5b5", size = 23147860, upload-time = "2026-06-01T19:42:57.748Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/56/deddff68533144d7c40a2793914fa2994d0273ef105144cbcd3c08f80eb3/uv-0.11.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0adb4553e7962132f4d3a3bcbdc49332008486fc7f3e147636c18fdc49dac17e", size = 23168337, upload-time = "2026-06-01T19:42:38.344Z" },
-    { url = "https://files.pythonhosted.org/packages/69/b0/71473c35536b92bc94a0ec317a7bddf800aeb90ad341044f61e17a45c6f4/uv-0.11.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9c2ab380ffafa1d754c92799ce818ce9bb20a5b053538e391fbdf0d10954a6a", size = 24543532, upload-time = "2026-06-01T19:43:03.348Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/74/00a422128320ed174c15b0ff7084533280850853592cf802c2f3e3bd25c2/uv-0.11.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73c59f8bca927b922b897a2d6123e45146dc97bfc73aab40ae10359ee37897c4", size = 25497616, upload-time = "2026-06-01T19:42:32.991Z" },
-    { url = "https://files.pythonhosted.org/packages/57/b9/a74e7a5029f7eebd7f8c45f6e87fbb2855705dd595980328e2403317a588/uv-0.11.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f2d8240e4b8eaa9507d423ede6cca8396057a24d398b89fbcc3117c79e8a42d", size = 24731187, upload-time = "2026-06-01T19:42:35.647Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/c4/8112b3c95db60a39c98db0641dd49bd4228f2fedb9d0ef5e4f3f48b52a0d/uv-0.11.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a4ee93dd0cc86046eb234ff8f3a5090c6cbb1466a825c5201aaf4ee4b45158d", size = 24868841, upload-time = "2026-06-01T19:42:46.905Z" },
-    { url = "https://files.pythonhosted.org/packages/39/5b/1adc8261a132604bac83438f77080b1cea4b87a633890c6b68dac0d68400/uv-0.11.18-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:57f4e2dea12cac7749628bc87eb66d3aaa5c3ed27420598899d6d82aee4d1b0d", size = 23536198, upload-time = "2026-06-01T19:42:41.196Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/16/44b5f182c5fc442ec8866c84cceec7675b7430417dcf119c1d5b656bce89/uv-0.11.18-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:8b7708376d0c79f84403d293c0774e0de76a7546e1cc80e911d0fed83cee65bf", size = 24290310, upload-time = "2026-06-01T19:43:15.415Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/43/021c0033918330f681eb3dafcf44db4b746978b0adb9c6851b2177597b56/uv-0.11.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:df158cc578aa4acff250505eab422a19794c9ff732dcab9faa068caa9dbe661d", size = 24380029, upload-time = "2026-06-01T19:43:12.746Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/38/2474a09f24ef57cfe99549a8d2d1a887549bab522a193ad50706a4fff021/uv-0.11.18-py3-none-musllinux_1_1_i686.whl", hash = "sha256:24f251b09f6dd7c367520b6b62e22038b92c18ce56ecee8b426a6cd78151466f", size = 23854064, upload-time = "2026-06-01T19:42:54.948Z" },
-    { url = "https://files.pythonhosted.org/packages/75/6a/faa140a30e993453400f94ad5675c9d0673a71191ff523d3117c312779a6/uv-0.11.18-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6e461d64cdc957da38fec9946758020ee3a66b4508f76cb940a866f704b20355", size = 25055765, upload-time = "2026-06-01T19:43:09.914Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/8a/077ded1832e92161fc880a420fbd513495369716531055215399d3056eba/uv-0.11.18-py3-none-win32.whl", hash = "sha256:97d60103eec0c4295c2728f0483def79d62a3f265baa11fdf94912c8f10be019", size = 22415962, upload-time = "2026-06-01T19:43:05.896Z" },
-    { url = "https://files.pythonhosted.org/packages/58/bc/68cf345e104a958f0b8971ae60a7d27c69b5892dcddc2e1d9e4a62c69931/uv-0.11.18-py3-none-win_amd64.whl", hash = "sha256:cbbedeb5fefd8c346fe2e1d71af229c04ece00a23ce277e9664db088d35c4f67", size = 25135111, upload-time = "2026-06-01T19:42:30.303Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/89/08bf00b50a62639129dd5c65b80a3182e9fddb67899739f9cfdc0ae1f138/uv-0.11.18-py3-none-win_arm64.whl", hash = "sha256:c9f61f96aa88ec1a890a50ca45fc05b51f4f066699e001245199895844708e38", size = 23542490, upload-time = "2026-06-01T19:42:44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR includes the implementation of stdio transport support and removal of uv from dev dependencies.

### feat: add stdio transport support
Why this change was needed:
To support MCP clients that run the server as a subprocess via `stdio` transport, which is common for desktop-based MCP clients like Claude Desktop.

Problem solved:
Clients can now interact with Bugzilla through a direct subprocess connection without needing to manage a network endpoint or HTTP headers for authentication.

What changed:
- Added `--transport` and `--api-key` CLI arguments.
- Added validation for `stdio` transport requirements and constraints.
- Updated server startup logic to support both `http` and `stdio` transports.
- Updated documentation in `README.md` and `CHANGELOG.md`.

### chore(deps): remove uv from dev dependencies
Why this change was needed:
uv is a tool used for managing the environment and should not be listed as a project-specific development dependency.

Problem solved:
Prevents redundant dependency declarations for environment-level tools.

What changed:
- Removed 'uv' from dev dependencies in pyproject.toml
