### PR TITLE
feat: add create_bug and add_attachment write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `create_bug` tool: file a new bug (product, component, summary, version,
+  description required; optional op_sys, platform, priority, severity, cc,
+  custom_fields). Returns the new bug id; the raw Bugzilla error is surfaced when
+  an instance mandates extra fields.
+- `add_attachment` tool: attach a (base64-encoded) file to a bug, with
+  content_type / is_patch / is_private / optional comment. Returns the created
+  attachment id(s).
+
+  Both are tagged `write`, so `--read-only` and
+  `MCP_BUGZILLA_DISABLED_METHODS` gate them like the other mutating tools.
+
 ## [v0.14.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ The server provides the following tools for interacting with Bugzilla:
   + **Returns**: A dictionary containing the updated bug fields including status `CLOSED`, resolution `DUPLICATE`, and `dupe_of` reference
   + **Example**: `mark_as_duplicate(12345, 789012, comment="Same root cause as the original report")`
 
+* **`create_bug(product, component, summary, version, description, op_sys="All", platform="All", priority=None, severity=None, cc=None, custom_fields=None)`**: Files a new bug.
+
+  + **Parameters**:
+    - `product`, `component`, `summary`, `version`, `description`: Required core fields
+    - `op_sys`, `platform`: Default to `All`
+    - `priority`, `severity`: Optional, instance-specific values
+    - `cc`: Optional list of email addresses to CC
+    - `custom_fields`: Optional dict of extra/custom fields (e.g. `{"cf_fixed_in": "1.2.3"}`)
+  + **Returns**: A dictionary with the new bug `id`. If the Bugzilla instance mandates additional fields, its error message is surfaced so you can retry with them.
+  + **Example**: `create_bug("MyProduct", "general", "App crashes on launch", "unspecified", "Steps to reproduce: ...")`
+
+* **`add_attachment(bug_id, file_name, summary, data, content_type="text/plain", is_patch=False, is_private=False, comment="")`**: Attaches a file to a bug.
+
+  + **Parameters**:
+    - `bug_id`: The bug to attach to
+    - `file_name`: File name shown in Bugzilla
+    - `summary`: Short description of the attachment
+    - `data`: The attachment content, **base64-encoded**
+    - `content_type`: MIME type (ignored when `is_patch=True`)
+    - `is_patch`: Mark the attachment as a patch
+    - `is_private`: Restrict to the insider group
+    - `comment`: Optional comment added alongside the attachment
+  + **Returns**: A dictionary with the created attachment `ids`
+  + **Example**: `add_attachment(12345, "crash.log", "Crash log", "aGVsbG8=", content_type="text/plain")`
+
 #### Bug Search
 
 - **`bugs_quicksearch(query: str, status: str = "ALL", include_fields: str = "...", limit: int = 50, offset: int = 0)`**: Executes a search for bugs using Bugzilla's powerful [quicksearch syntax](https://bugzilla.readthedocs.io/en/latest/using/finding.html#quicksearch).

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -322,3 +322,57 @@ class Bugzilla:
         mcp_log.info("[BZ-RES] Bug updated successfully")
         mcp_log.debug(f"[BZ-RES] {data}")
         return data
+
+    async def create_bug(self, fields: dict[str, Any]) -> dict[str, Any]:
+        """Create a new bug from the given field mapping.
+
+        Bugzilla requires at least product, component, summary, version and
+        description; instances may mandate more. The raw Bugzilla error (e.g.
+        a missing required field) is surfaced to the caller.
+        """
+        url = "/bug"
+        mcp_log.info(f"[BZ-REQ] POST {self.api_url}{url} json={fields}")
+
+        try:
+            r = await self.client.post(url, json=fields)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        data = r.json()
+        mcp_log.info(f"[BZ-RES] Created bug {data.get('id')}")
+        mcp_log.debug(f"[BZ-RES] {data}")
+        return data
+
+    async def add_attachment(
+        self, bug_id: int, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Attach a file to a bug. ``payload['data']`` is base64-encoded."""
+        url = f"/bug/{bug_id}/attachment"
+        # Don't log the (possibly large / binary) base64 blob.
+        mcp_log.info(
+            f"[BZ-REQ] POST {self.api_url}{url} file_name={payload.get('file_name')!r}"
+        )
+
+        try:
+            r = await self.client.post(url, json=payload)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        data = r.json()
+        mcp_log.info(f"[BZ-RES] Attachment(s) {data.get('ids')} added to bug {bug_id}")
+        mcp_log.debug(f"[BZ-RES] {data}")
+        return data

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -520,6 +520,130 @@ async def mark_as_duplicate(
         raise ToolError(f"Failed to mark as duplicate\n{e}")
 
 
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
+    tags={"write"},
+)
+async def create_bug(
+    product: str,
+    component: str,
+    summary: str,
+    version: str,
+    description: str,
+    op_sys: str = "All",
+    platform: str = "All",
+    priority: Optional[str] = None,
+    severity: Optional[str] = None,
+    cc: Optional[list[str]] = None,
+    custom_fields: Optional[dict[str, Any]] = None,
+    bz: Bugzilla = Depends(get_bz),
+) -> dict[str, Any]:
+    """Create a new bug. Returns the new bug id on success.
+
+    Required fields: product, component, summary, version, description. Some
+    Bugzilla instances mandate additional fields; the raw Bugzilla error is
+    surfaced when that happens (inspect it and retry with the missing field).
+
+    Args:
+        product: Product the bug is filed against
+        component: Component within the product
+        summary: One-line bug summary
+        version: Affected product version (e.g. "unspecified")
+        description: Initial bug description (the first comment)
+        op_sys: Operating system (default "All")
+        platform: Hardware platform (default "All")
+        priority: Optional priority (e.g. P1..P5 / high..low, instance-specific)
+        severity: Optional severity (e.g. critical, normal, minor)
+        cc: Optional list of email addresses to CC
+        custom_fields: Optional dict of extra/custom fields, e.g. {"cf_foo": "bar"}
+    """
+    mcp_log.info(
+        f"[LLM-REQ] create_bug(product={product!r}, component={component!r}, "
+        f"summary={summary!r}, version={version!r})"
+    )
+
+    fields: dict[str, Any] = {
+        "product": product,
+        "component": component,
+        "summary": summary,
+        "version": version,
+        "description": description,
+        "op_sys": op_sys,
+        "platform": platform,
+    }
+    if priority:
+        fields["priority"] = priority
+    if severity:
+        fields["severity"] = severity
+    if cc:
+        fields["cc"] = cc
+    if custom_fields:
+        fields.update(custom_fields)
+
+    try:
+        return await bz.create_bug(fields)
+    except Exception as e:
+        raise ToolError(f"Failed to create bug\n{e}")
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
+    tags={"write"},
+)
+async def add_attachment(
+    bug_id: int,
+    file_name: str,
+    summary: str,
+    data: str,
+    content_type: str = "text/plain",
+    is_patch: bool = False,
+    is_private: bool = False,
+    comment: str = "",
+    bz: Bugzilla = Depends(get_bz),
+) -> dict[str, Any]:
+    """Attach a file to a bug. Returns the created attachment id(s).
+
+    Args:
+        bug_id: Bug to attach the file to
+        file_name: File name shown in Bugzilla
+        summary: Short description of the attachment
+        data: The attachment content, **base64-encoded** (binary-safe)
+        content_type: MIME type (ignored by Bugzilla when is_patch=True)
+        is_patch: Mark the attachment as a patch
+        is_private: Restrict the attachment to the insider group
+        comment: Optional comment to add alongside the attachment
+    """
+    mcp_log.info(
+        f"[LLM-REQ] add_attachment(bug_id={bug_id}, file_name={file_name!r}, "
+        f"is_patch={is_patch}, is_private={is_private})"
+    )
+
+    payload: dict[str, Any] = {
+        "ids": [bug_id],
+        "file_name": file_name,
+        "summary": summary,
+        "data": data,
+        "content_type": content_type,
+        "is_patch": is_patch,
+        "is_private": is_private,
+    }
+    if comment:
+        payload["comment"] = comment
+
+    try:
+        return await bz.add_attachment(bug_id, payload)
+    except Exception as e:
+        raise ToolError(f"Failed to add attachment\n{e}")
+
+
 def disable_components_selectively():
     """
     Disables MCP components based on environment variables.

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -171,6 +171,77 @@ async def test_add_comment(bz_client):
 
 
 @pytest.mark.asyncio
+async def test_create_bug(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.post("/rest/bug").mock(
+            return_value=Response(200, json={"id": 777})
+        )
+
+        fields = {
+            "product": "TestProduct",
+            "component": "TestComponent",
+            "summary": "A new bug",
+            "version": "unspecified",
+            "description": "Steps to reproduce ...",
+        }
+        resp = await bz_client.create_bug(fields)
+
+        assert resp == {"id": 777}
+        assert route.called
+        # API key is forwarded and the fields are in the POST body.
+        assert bz_client.api_key in str(route.calls.last.request.url)
+        body = route.calls.last.request.content
+        assert b'"product"' in body
+        assert b"TestComponent" in body
+
+
+@pytest.mark.asyncio
+async def test_create_bug_missing_required_field_surfaces_error(bz_client):
+    """A Bugzilla validation error (missing field) propagates to the caller."""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.post("/rest/bug").mock(
+            return_value=Response(
+                400,
+                json={
+                    "error": True,
+                    "message": "You must select/enter a component.",
+                    "code": 106,
+                },
+            )
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await bz_client.create_bug({"product": "P", "summary": "S"})
+
+        assert (
+            "400" in str(exc_info.value) or "component" in str(exc_info.value).lower()
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_attachment(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.post("/rest/bug/123/attachment").mock(
+            return_value=Response(201, json={"ids": [42]})
+        )
+
+        payload = {
+            "ids": [123],
+            "file_name": "log.txt",
+            "summary": "failing testsuite output",
+            "data": "aGVsbG8=",  # base64("hello")
+            "content_type": "text/plain",
+        }
+        resp = await bz_client.add_attachment(123, payload)
+
+        assert resp == {"ids": [42]}
+        assert route.called
+        body = route.calls.last.request.content
+        assert b"aGVsbG8=" in body
+        assert b"log.txt" in body
+
+
+@pytest.mark.asyncio
 async def test_quicksearch(bz_client):
     async with respx.mock(base_url=MOCK_URL) as respx_mock:
         route = respx_mock.get("/rest/bug").mock(


### PR DESCRIPTION
## Summary

The server already supports commenting (`add_comment`) and mutating bug
state/fields/assignee/CC/dependencies. The two remaining write capabilities were
**filing a new bug** and **attaching a file** — added here.

## Changes

- `Bugzilla.create_bug(fields)` → `POST /rest/bug`, returns `{"id": <new bug>}`.
  Raw Bugzilla validation errors (e.g. a missing required field) are surfaced so
  the caller can retry with the missing field.
- `Bugzilla.add_attachment(bug_id, payload)` → `POST /rest/bug/{id}/attachment`
  with **base64-encoded** data, returns `{"ids": [<attachment id>]}`.
- `create_bug` and `add_attachment` MCP tools wrapping them, following the
  existing tool idiom (`Depends(get_bz)`, `ToolError` on failure). Both are
  tagged `write`, so `--read-only` and `MCP_BUGZILLA_DISABLED_METHODS` gate them
  exactly like the other mutating tools. `add_attachment` takes pre-base64-encoded
  `data` (binary-safe) and never logs the blob.

## Tests

`respx`-mocked client tests: `create_bug` success, `create_bug` missing-field
error propagation, `add_attachment` success. Full suite: 30 passed.

`ruff format --check` clean.

## Docs

README "Write Operations" and CHANGELOG `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)