### PR TITLE
fix: surface Bugzilla error message on 4xx bug updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [Unreleased]
+
+### Fixed
+- Surface Bugzilla API error message/code on 4xx responses (e.g., validation rejection on HTTP 404) by raising `BugzillaAPIError` instead of generic HTTP status text.
+
+### Changed
+- Require resolution when setting status to `RESOLVED` as well as `CLOSED` in `update_bug_status`.
+
 ## [v0.15.1] - 2026-06-22
 - Fix incorrect PyPi publishing
 

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -58,6 +58,29 @@ mcp_log.addHandler(handler)
 mcp_log.propagate = False
 
 
+class BugzillaAPIError(Exception):
+    """Bugzilla REST API error with code and message."""
+
+    def __init__(self, status_code: int, error: dict[str, Any]):
+        self.status_code = status_code
+        self.code = error.get("code")
+        self.message = error.get("message", "Unknown error")
+        super().__init__(
+            f"Bugzilla API error {self.code} (HTTP {status_code}): {self.message}"
+        )
+
+
+def _bugzilla_error_body(response: httpx.Response) -> Optional[dict[str, Any]]:
+    """Parse Bugzilla error from response body, if present."""
+    try:
+        body = response.json()
+        if isinstance(body, dict) and body.get("error") and "message" in body:
+            return body
+    except Exception:
+        pass
+    return None
+
+
 class Bugzilla:
     """Async Bugzilla API client"""
 
@@ -311,6 +334,12 @@ class Bugzilla:
             r = await self.client.put(url, json=payload)
             r.raise_for_status()
         except httpx.HTTPStatusError as e:
+            if (bz_error := _bugzilla_error_body(e.response)) is not None:
+                # Surface structured Bugzilla error (e.g., validation rejection)
+                mcp_log.error(
+                    f"[BZ-RES] Failed: {e.response.status_code} code={bz_error.get('code')} {bz_error['message']}"
+                )
+                raise BugzillaAPIError(e.response.status_code, bz_error) from e
             mcp_log.error(
                 f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
             )

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -316,30 +316,31 @@ async def update_bug_status(
 ) -> dict[str, Any]:
     """Update the status of a bug. Optionally add a comment explaining the status change.
 
-    Valid statuses: NEW, ASSIGNED, MODIFIED, ON_QA, VERIFIED, CLOSED
-    For CLOSED, you MUST also provide a resolution (FIXED, WONTFIX, NOTABUG, DUPLICATE, etc.)
+    Valid statuses are instance-specific. Common resolved states are CLOSED and
+    RESOLVED (e.g. bugzilla.suse.com). Both require a resolution.
 
     Args:
         bug_id: Bug ID to update
         status: New status
-        resolution: Resolution (required when status is CLOSED)
+        resolution: Resolution (required when status is CLOSED or RESOLVED)
         comment: Optional comment explaining the change
     """
     mcp_log.info(
         f"[LLM-REQ] update_bug_status(bug_id={bug_id}, status='{status}', resolution={resolution}, comment='{comment[:50] if comment else ''}...')"
     )
 
+    resolved_states = ("CLOSED", "RESOLVED", "VERIFIED")
+
     updates = {"status": status}
     if resolution:
         updates["resolution"] = resolution
-    elif status not in ("CLOSED", "VERIFIED"):
-        # Clear resolution when reopening
-        updates["resolution"] = ""
+    elif status not in resolved_states:
+        updates["resolution"] = ""  # Clear resolution when reopening
 
-    # Validate: CLOSED requires resolution
-    if status == "CLOSED" and not resolution:
+    # Validate: a resolved state requires a resolution
+    if status in ("CLOSED", "RESOLVED") and not resolution:
         raise ToolError(
-            "Resolution is required when setting status to CLOSED (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE)"
+            f"Resolution is required when setting status to {status} (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE)"
         )
 
     try:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -517,10 +517,30 @@ async def test_update_bug_not_found(bz_client):
         with pytest.raises(Exception) as exc_info:
             await bz_client.update_bug(bug_id=999999, updates={"priority": "high"})
 
-        assert (
-            "404" in str(exc_info.value)
-            or "does not exist" in str(exc_info.value).lower()
+        assert "does not exist" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_invalid_value_404_surfaces_message(bz_client):
+    """Ensure Bugzilla's error message is surfaced for a 404 response with a JSON error body."""
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.put("/rest/bug/123").mock(
+            return_value=Response(
+                404,
+                json={
+                    "code": 51,
+                    "error": True,
+                    "message": "There is no status named 'CLOSED'.",
+                },
+            )
         )
+
+        with pytest.raises(Exception) as exc_info:
+            await bz_client.update_bug(
+                bug_id=123, updates={"status": "CLOSED", "resolution": "FIXED"}
+            )
+
+        assert "no status named 'closed'" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi, when using the MCP server I ran into a problem with closing Bugzilla issues. First problem was returning generic 4xx making it seem like the MCP server/Bugzilla instance don't work for some reason. After fixing that, I found out that not every instance shares the same statuses, and unfortunately for me the SUSE one specifically seems to differ from the default ("RESOLVED" instead of "CLOSED").

This PR makes the returned errors more explicit and it also checks for both "CLOSED" and "RESOLVED" as the states indicating closure. I changed the comment that claims which statuses are valid - this doesn't make sense where an instance can change this (but perhaps mentioning these are the default is better?).