### PR TITLE
Add --allow-anonymous flag for unauthenticated read-only access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `--allow-anonymous` flag (env `MCP_ALLOW_ANONYMOUS`): allow anonymous (unauthenticated) access when no API key is provided, for read-only access to a public Bugzilla. Off by default; works in both `http` and `stdio` transports and pairs well with `--read-only`.
+
 ## [v0.16.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The `mcp-bugzilla` command supports the following options:
 | `--api-key-header <HEADER_NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name for the Bugzilla API key (http transport only) |
 | `--use-auth-header` | `USE_AUTH_HEADER` | `False` | Use `Authorization: Bearer` header instead of `api_key` query parameter |
 | `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
+| `--allow-anonymous` | `MCP_ALLOW_ANONYMOUS` | `False` | Allow anonymous (unauthenticated) access when no API key is provided. Useful for read-only access to a public Bugzilla. Off by default |
 | `--download-dir <DIR>` | `BUGZILLA_DOWNLOAD_DIR` | `<tmpdir>/mcp-bugzilla` | Directory where `download_attachment` writes binary/oversized attachments. The default directory is created on first use and restricted to the owner (`0o700`); an explicit `output_dir` keeps its own permissions |
 
 **Note**: `--host` and `--port` are rejected with an error when used together with `--transport stdio`.

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -65,6 +65,14 @@ def main():
         help="Bugzilla API key. Required for --transport stdio (no HTTP headers exist there). Environment variable BUGZILLA_API_KEY can also be used. Ignored for --transport http (clients send the key per-request via the API key header).",
     )
     parser.add_argument(
+        "--allow-anonymous",
+        action="store_true",
+        default=os.getenv("MCP_ALLOW_ANONYMOUS", "false").lower() == "true",
+        help="Allow anonymous (unauthenticated) access when no API key is provided. "
+        "Useful for read-only access to a public Bugzilla. Environment variable "
+        "MCP_ALLOW_ANONYMOUS=true can also be used. Off by default.",
+    )
+    parser.add_argument(
         "--download-dir",
         type=str,
         default=os.getenv("BUGZILLA_DOWNLOAD_DIR"),
@@ -97,9 +105,10 @@ def main():
         )
         if explicit_host_or_port:
             parser.error("--host/--port are not valid with --transport stdio")
-        if not args.api_key:
+        if not args.api_key and not args.allow_anonymous:
             parser.error(
-                "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
+                "--transport stdio requires --api-key or the BUGZILLA_API_KEY "
+                "environment variable (or --allow-anonymous for public read-only access)"
             )
     elif args.transport == "http" and args.api_key:
         # In http mode the server takes the API key from each client's per-request

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -90,10 +90,11 @@ class Bugzilla:
         self.api_key = api_key
         params = {}
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        if use_auth_header:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        else:
-            params["api_key"] = self.api_key
+        if self.api_key:
+            if use_auth_header:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            else:
+                params["api_key"] = self.api_key
         # We'll use a single client for the instance
         self.client = httpx.AsyncClient(
             base_url=self.api_url,

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -61,7 +61,7 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
 
     if transport == "stdio":
         api_key_value = getattr(cli_args, "api_key", None)
-        if not api_key_value:
+        if not api_key_value and not getattr(cli_args, "allow_anonymous", False):
             # Defense in depth; main() already validates this at startup.
             raise ValidationError(
                 "stdio transport requires --api-key or BUGZILLA_API_KEY env var"
@@ -69,13 +69,13 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
     else:
         api_key_header = getattr(cli_args, "api_key_header", "ApiKey")
         api_key_value = headers.get(api_key_header.lower())
-        if not api_key_value:
+        if not api_key_value and not getattr(cli_args, "allow_anonymous", False):
             raise ValidationError(f"`{api_key_header}` header is required")
 
     mcp_log.debug("api_key: Found")
     bz = Bugzilla(
         url=base_url,
-        api_key=api_key_value,
+        api_key=api_key_value or "",
         use_auth_header=getattr(cli_args, "use_auth_header", False),
     )
     try:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -668,3 +668,33 @@ def test_is_textual(content_type, expected):
 )
 def test_safe_filename(name, expected):
     assert safe_filename(name, 7) == expected
+
+
+@pytest.mark.asyncio
+async def test_anonymous_client_sends_no_api_key():
+    # Empty API key => anonymous access: no api_key query param is sent.
+    client = Bugzilla(MOCK_URL, "")
+    try:
+        async with respx.mock(base_url=MOCK_URL) as respx_mock:
+            route = respx_mock.get("/rest/version").mock(
+                return_value=Response(200, json={"version": "5.0.4"})
+            )
+            await client.server_version()
+            assert "api_key" not in route.calls.last.request.url.params
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_anonymous_client_sends_no_auth_header():
+    # Empty API key with use_auth_header => no Authorization header is sent.
+    client = Bugzilla(MOCK_URL, "", use_auth_header=True)
+    try:
+        async with respx.mock(base_url=MOCK_URL) as respx_mock:
+            route = respx_mock.get("/rest/version").mock(
+                return_value=Response(200, json={"version": "5.0.4"})
+            )
+            await client.server_version()
+            assert "authorization" not in route.calls.last.request.headers
+    finally:
+        await client.close()


### PR DESCRIPTION
Fixes #108.

Public Bugzilla instances (e.g. https://bugzilla.altlinux.org) allow anonymous read access to public bugs via the REST API, but the server currently hard-requires an API key in both `http` and `stdio`, and always forwards the key (so even a throwaway key is rejected by Bugzilla). There was no way to run purely for anonymous, read-only access.

This adds an opt-in `--allow-anonymous` flag (env `MCP_ALLOW_ANONYMOUS`), **off by default** so existing behavior is unchanged. When enabled:

- `get_bz()` no longer requires a key (http header / stdio `--api-key`) — it uses an empty key;
- `Bugzilla` sends **no** `api_key` query param / `Authorization` header when the key is empty → a genuine anonymous request.

Pairs naturally with `--read-only` for public, read-only use.

### Changes
- `--allow-anonymous` CLI flag + `MCP_ALLOW_ANONYMOUS` env (argparse).
- `get_bz()`: skip the key requirement when `--allow-anonymous` (both transports).
- `Bugzilla.__init__`: only attach `api_key` / `Authorization` when the key is non-empty.
- Tests: anonymous client sends no `api_key` param and no `Authorization` header.
- README (arguments table) + CHANGELOG.

### Testing
`uv run pytest` → 52 passed (2 new).
