### PR TITLE
refactor(auth): replace api-key-header/use-auth-header/api-key with clearer params; add anonymous access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Optional flags:
 |------|-------------|
 | `--host` | Listen address (default: `127.0.0.1`) |
 | `--port` | Listen port (default: `8000`) |
-| `--mcp-auth-header` | Header name for client API key (default: `ApiKey`; env: `MCP_AUTH_HEADER`) |
+| `--mcp-auth-header` | Header name for client API key (disabled by default; env: `MCP_AUTH_HEADER`) |
 | `--bugzilla-api-key` | Static Bugzilla API key; if omitted access is anonymous (env: `BUGZILLA_API_KEY`) |
 | `--bugzilla-auth-mode` | How to authenticate with Bugzilla: `query` (default) or `bearer` for `Authorization: Bearer` (env: `BUGZILLA_AUTH_MODE`) |
 | `--read-only` | Disable all write tools |
@@ -71,7 +71,7 @@ Combined with `--read-only` to restrict to a specific read-only subset.
 
 ## Authentication Flow
 
-- Clients (http transport) send a Bugzilla API key in an HTTP header (default header name: `ApiKey`, configurable via `--mcp-auth-header`).
+- Clients (http transport) send a Bugzilla API key in an HTTP header (only enabled when `--mcp-auth-header` or `MCP_AUTH_HEADER` is explicitly configured).
 - For stdio transport, the key comes from `--bugzilla-api-key` / `BUGZILLA_API_KEY`.
 - If no non-empty key is found from any source, access is **anonymous** (no credentials sent to Bugzilla).
 - When a key is present, the server forwards it to Bugzilla either as:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Combined with `--read-only` to restrict to a specific read-only subset.
 - If no non-empty key is found from any source, access is **anonymous** (no credentials sent to Bugzilla).
 - When a key is present, the server forwards it to Bugzilla either as:
   - `?api_key=...` query parameter (`--bugzilla-auth-mode query`, default), or
-  - `Authorization: ****** header (`--bugzilla-auth-mode bearer`, required for Red Hat Bugzilla).
+  - `Authorization: Bearer <KEY>` header (`--bugzilla-auth-mode bearer`, required for Red Hat Bugzilla).
 
 ## Docker / Podman
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,18 @@ Optional flags:
 |------|-------------|
 | `--host` | Listen address (default: `127.0.0.1`) |
 | `--port` | Listen port (default: `8000`) |
-| `--api-key-header` | Header name for client API key (default: `ApiKey`) |
-| `--use-auth-header` | Send API key as `Authorization: Bearer` to Bugzilla (for Red Hat Bugzilla etc.) |
+| `--mcp-auth-header` | Header name for client API key (default: `ApiKey`; env: `MCP_AUTH_HEADER`) |
+| `--bugzilla-api-key` | Static Bugzilla API key; if omitted access is anonymous (env: `BUGZILLA_API_KEY`) |
+| `--bugzilla-auth-mode` | How to authenticate with Bugzilla: `query` (default) or `bearer` for `Authorization: Bearer` (env: `BUGZILLA_AUTH_MODE`) |
 | `--read-only` | Disable all write tools |
+
+**Deprecated flags** (still work but log a warning — migrate to the replacements above):
+
+| Deprecated Flag | Replacement |
+|-----------------|-------------|
+| `--api-key-header` / `MCP_API_KEY_HEADER` | `--mcp-auth-header` / `MCP_AUTH_HEADER` |
+| `--api-key` | `--bugzilla-api-key` / `BUGZILLA_API_KEY` |
+| `--use-auth-header` | `--bugzilla-auth-mode bearer` |
 
 ## Running Tests
 
@@ -62,10 +71,12 @@ Combined with `--read-only` to restrict to a specific read-only subset.
 
 ## Authentication Flow
 
-- Clients send a Bugzilla API key in an HTTP header (default header name: `ApiKey`).
-- The server extracts this key per-request and forwards it to Bugzilla either as:
-  - `?api_key=...` query parameter (default), or
-  - `Authorization: Bearer ...` header (`--use-auth-header`).
+- Clients (http transport) send a Bugzilla API key in an HTTP header (default header name: `ApiKey`, configurable via `--mcp-auth-header`).
+- For stdio transport, the key comes from `--bugzilla-api-key` / `BUGZILLA_API_KEY`.
+- If no non-empty key is found from any source, access is **anonymous** (no credentials sent to Bugzilla).
+- When a key is present, the server forwards it to Bugzilla either as:
+  - `?api_key=...` query parameter (`--bugzilla-auth-mode query`, default), or
+  - `Authorization: ****** header (`--bugzilla-auth-mode bearer`, required for Red Hat Bugzilla).
 
 ## Docker / Podman
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The server provides the following tools for interacting with Bugzilla:
 
 - Python 3.13
 - A Bugzilla instance with REST API access
-- A Bugzilla user account with an API key
+- A Bugzilla user account with an API key *(optional: public instances support anonymous access)*
 - Network access to the Bugzilla server
 
 ## Installation
@@ -270,15 +270,26 @@ The `mcp-bugzilla` command supports the following options:
 | `--transport {http,stdio}` | `MCP_TRANSPORT` | `http` | Transport for the MCP server. `stdio` is for direct subprocess launches by an MCP client; `http` exposes a network endpoint |
 | `--host <ADDRESS>` | `MCP_HOST` | `127.0.0.1` | Host address for the MCP server to listen on (http transport only) |
 | `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on (http transport only) |
-| `--api-key <KEY>` | `BUGZILLA_API_KEY` | *Required for stdio* | Bugzilla API key. Required with `--transport stdio` (no HTTP headers exist there). Ignored for `--transport http`, where clients send the key per-request via the API key header |
-| `--api-key-header <HEADER_NAME>` | `MCP_API_KEY_HEADER` | `ApiKey` | HTTP header name for the Bugzilla API key (http transport only) |
-| `--use-auth-header` | `USE_AUTH_HEADER` | `False` | Use `Authorization: Bearer` header instead of `api_key` query parameter |
+| `--mcp-auth-header <HEADER>` | `MCP_AUTH_HEADER` | `ApiKey` | HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). If the client omits this header, access falls back to `--bugzilla-api-key` or is anonymous |
+| `--bugzilla-api-key <KEY>` | `BUGZILLA_API_KEY` | *none* | Static Bugzilla API key. Optional: if omitted and not provided per-request via `--mcp-auth-header` (http), access is **anonymous**. For `--transport stdio` this is the only source of the key |
+| `--bugzilla-auth-mode {query,bearer}` | `BUGZILLA_AUTH_MODE` | `query` | How to authenticate with Bugzilla: `query` sends `?api_key=<KEY>` (default, works with most instances); `bearer` sends `Authorization: ****** (required for Red Hat Bugzilla and similar) |
 | `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
 | `--download-dir <DIR>` | `BUGZILLA_DOWNLOAD_DIR` | `<tmpdir>/mcp-bugzilla` | Directory where `download_attachment` writes binary/oversized attachments. The default directory is created on first use and restricted to the owner (`0o700`); an explicit `output_dir` keeps its own permissions |
 
 **Note**: `--host` and `--port` are rejected with an error when used together with `--transport stdio`.
 
 **Note**: Command-line arguments take precedence over environment variables.
+
+#### Deprecated Arguments
+
+The following arguments are **deprecated** and will be removed in a future release. They continue to work
+and emit a warning in the logs when used. Migrate to the replacements shown:
+
+| Deprecated | Replacement | Notes |
+|------------|-------------|-------|
+| `--api-key` / `BUGZILLA_API_KEY` (old semantics) | `--bugzilla-api-key` / `BUGZILLA_API_KEY` | Same env var; the new arg makes the intent explicit. Previously required for stdio; now optional (anonymous if absent) |
+| `--api-key-header` / `MCP_API_KEY_HEADER` | `--mcp-auth-header` / `MCP_AUTH_HEADER` | Clarifies that this controls the *inbound* client→MCP header |
+| `--use-auth-header` | `--bugzilla-auth-mode bearer` | Replaces a boolean flag with an explicit mode choice |
 
 ### Environment Variables
 
@@ -288,7 +299,9 @@ You can configure the server using environment variables instead of command-line
 export BUGZILLA_SERVER=https://bugzilla.example.com
 export MCP_HOST=127.0.0.1
 export MCP_PORT=8000
-export MCP_API_KEY_HEADER=ApiKey
+export MCP_AUTH_HEADER=ApiKey
+export BUGZILLA_API_KEY=your_api_key   # optional; omit for anonymous access
+export BUGZILLA_AUTH_MODE=query        # or "bearer" for Red Hat Bugzilla
 export LOG_LEVEL=INFO  # Optional: DEBUG, INFO, WARNING, ERROR, CRITICAL
 export MCP_READ_ONLY=true  # Optional: set to true to disable write operations
 # Selective Disabling Tools (Optional)
@@ -319,11 +332,15 @@ The server will start listening on `http://127.0.0.1:8000/mcp/` by default.
 
 #### Stdio transport
 
-For MCP clients that launch the server as a subprocess and speak over stdin/stdout (e.g. Claude Desktop-style configs), use `--transport stdio`. Because there is no per-request HTTP scope, the Bugzilla API key must be provided up front via `BUGZILLA_API_KEY` or `--api-key`:
+For MCP clients that launch the server as a subprocess and speak over stdin/stdout (e.g. Claude Desktop-style configs), use `--transport stdio`. To authenticate with Bugzilla, provide the API key via `BUGZILLA_API_KEY` or `--bugzilla-api-key`. If the key is omitted, access is **anonymous**:
 
 ```bash
-BUGZILLA_API_KEY=your_api_key \
+# Authenticated stdio
+BUGZILLA_API_KEY=your_api_key \\
   mcp-bugzilla --bugzilla-server https://bugzilla.opensuse.org --transport stdio
+
+# Anonymous stdio (public Bugzilla instances)
+mcp-bugzilla --bugzilla-server https://bugzilla.opensuse.org --transport stdio --read-only
 ```
 
 `--host` and `--port` are not valid in stdio mode and will cause the server to exit with an error.
@@ -343,65 +360,56 @@ http://127.0.0.1:8000/mcp/
 
 ### Authentication
 
-**Required**: All requests must include a Bugzilla API key in the HTTP headers.
+Authentication is **optional**. If no API key is provided, the server accesses Bugzilla anonymously, which works for public read-only operations on Bugzilla instances that allow anonymous access.
 
-1. **Generate an API Key**:
-   - Log in to your Bugzilla instance
-   - Navigate to your user preferences
-   - Go to the "API Keys" section
-   - Generate a new API key
-   - Copy the API key
+#### Sending the API key from the MCP client (http transport)
 
-2. **Send the API Key**:
-   Include the API key in the HTTP request header. By default, the header name is `ApiKey`:
+Include the Bugzilla API key in the HTTP request header sent to this MCP server. By default, the header name is `ApiKey` (configurable via `--mcp-auth-header` / `MCP_AUTH_HEADER`):
 
-   ```http
-   POST /mcp/ HTTP/1.1
-   Host: 127.0.0.1:8000
-   ApiKey: YOUR_API_KEY_HERE
-   Content-Type: application/json
-   ```
+```http
+POST /mcp/ HTTP/1.1
+Host: 127.0.0.1:8000
+ApiKey: YOUR_API_KEY_HERE
+Content-Type: application/json
+```
 
-   You can customize the header name using the `--api-key-header` argument or `MCP_API_KEY_HEADER` environment variable.
+If the client omits the `ApiKey` header, the server falls back to the `--bugzilla-api-key` / `BUGZILLA_API_KEY` static key, or uses anonymous access if that is also unset.
 
-3. **Example with curl**:
-   ```bash
-   curl -X POST http://127.0.0.1:8000/mcp/ \
-     -H "ApiKey: YOUR_API_KEY_HERE" \
-     -H "Content-Type: application/json" \
-     -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "server_url_resource"}, "id": 1}'
-   ```
+**Example with curl**:
+```bash
+curl -X POST http://127.0.0.1:8000/mcp/ \\
+  -H "ApiKey: YOUR_API_KEY_HERE" \\
+  -H "Content-Type: application/json" \\
+  -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "server_url_resource"}, "id": 1}'
+```
 
-### Authentication Methods
+### MCP → Bugzilla Authentication Modes
 
-This server supports two authentication methods for communicating with Bugzilla:
+The `--bugzilla-auth-mode` argument controls how this server authenticates with Bugzilla:
 
-#### Method 1: Query Parameter (Default)
+#### Mode `query` (Default)
 
-By default, the server sends the API key as a query parameter in the URL:
+Sends the API key as the `api_key` query parameter in every Bugzilla REST request:
 ```bash
 mcp-bugzilla --bugzilla-server https://bugzilla.example.com
+# Equivalent: --bugzilla-auth-mode query
 ```
 
 This works with standard Bugzilla instances (Mozilla Bugzilla, openSUSE Bugzilla, etc.).
 
-#### Method 2: Authorization Header (for enterprise instances)
+#### Mode `bearer` (for enterprise instances)
 
-Some Bugzilla instances (such as Red Hat Bugzilla) require the API key to be sent via the `Authorization: Bearer` header instead of as a query parameter. Use the `--use-auth-header` flag for these instances:
+Some Bugzilla instances (such as Red Hat Bugzilla) require the API key to be sent via the `Authorization: Bearer` header. Use `--bugzilla-auth-mode bearer` for these instances:
 ```bash
-mcp-bugzilla --bugzilla-server https://bugzilla.redhat.com --use-auth-header
+mcp-bugzilla --bugzilla-server https://bugzilla.redhat.com --bugzilla-auth-mode bearer
 ```
 
-**When to use `--use-auth-header`:**
+**When to use `bearer` mode:**
 - Red Hat Bugzilla (bugzilla.redhat.com)
 - Other enterprise Bugzilla instances that reject `api_key` query parameters
 - Bugzilla instances with strict authentication requirements
 
-**How it works:**
-- **With `--use-auth-header`**: Sends `Authorization: Bearer YOUR_API_KEY` header to Bugzilla
-- **Without `--use-auth-header`** (default): Sends `?api_key=YOUR_API_KEY` query parameter to Bugzilla
-
-**Note**: The `--api-key-header` option controls which header name the *MCP server* expects from *clients*, while `--use-auth-header` controls how the *MCP server* authenticates with *Bugzilla*. These are independent settings.
+**Note**: `--mcp-auth-header` controls which header the *MCP clients* use to pass the key *to this server*; `--bugzilla-auth-mode` controls how *this server* forwards it *to Bugzilla*. These are independent settings.
 
 ### MCP Client Integration
 
@@ -432,7 +440,7 @@ All tools return JSON responses following the MCP protocol. Successful responses
 
 The server provides detailed error messages for common issues:
 
-- **Missing API Key**: Returns `ValidationError` if the required API key header is missing
+- **Authentication**: API key is optional; if absent, access is anonymous. If Bugzilla returns 401, your key may be invalid or the instance requires authentication.
 - **Invalid Bug ID**: Returns `ToolError` with details if a bug ID doesn't exist
 - **API Errors**: Returns `ToolError` with the HTTP status code and error message from Bugzilla
 - **Network Errors**: Returns `ToolError` for connection or timeout issues
@@ -530,16 +538,15 @@ page2 = bugs_quicksearch("status:NEW", limit=50, offset=50)
 
 ### Example 6: Using with Red Hat Bugzilla
 
-Red Hat Bugzilla requires Authorization header authentication:
+Red Hat Bugzilla requires `Authorization: Bearer` authentication instead of the default `api_key` query parameter. Use `--bugzilla-auth-mode bearer`:
 ```bash
-# Start the server with --use-auth-header flag
 mcp-bugzilla \
   --bugzilla-server https://bugzilla.redhat.com \
-  --use-auth-header \
+  --bugzilla-auth-mode bearer \
   --host 127.0.0.1 \
   --port 8000
 
-# Client connects normally - the flag only affects server-to-Bugzilla communication
+# Client sends the key in the ApiKey header as usual
 curl -X POST http://127.0.0.1:8000/mcp/ \
   -H "ApiKey: YOUR_API_KEY_HERE" \
   -H "Content-Type: application/json" \
@@ -591,12 +598,12 @@ mcp-bugzilla --bugzilla-server https://bugzilla.example.com
 
 ### Authentication Errors
 
-**Issue**: Receiving `ValidationError: ApiKey header is required`
+**Issue**: Receiving 401 Unauthorized from Bugzilla
 
 **Solution**: 
-1. Ensure you're sending the API key in the correct HTTP header (default: `ApiKey`)
+1. Ensure you're sending the API key in the correct HTTP header to the MCP server (default: `ApiKey`, or configure with `--mcp-auth-header`)
 2. Verify the API key is valid and not expired
-3. Check that the header name matches your server configuration
+3. Check that `--bugzilla-auth-mode` matches what the Bugzilla instance expects (`query` for standard instances, `bearer` for Red Hat Bugzilla)
 
 ### API Errors
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ The `mcp-bugzilla` command supports the following options:
 | `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on (http transport only) |
 | `--mcp-auth-header <HEADER>` | `MCP_AUTH_HEADER` | `ApiKey` | HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). If the client omits this header, access falls back to `--bugzilla-api-key` or is anonymous |
 | `--bugzilla-api-key <KEY>` | `BUGZILLA_API_KEY` | *none* | Static Bugzilla API key. Optional: if omitted and not provided per-request via `--mcp-auth-header` (http), access is **anonymous**. For `--transport stdio` this is the only source of the key |
-| `--bugzilla-auth-mode {query,bearer}` | `BUGZILLA_AUTH_MODE` | `query` | How to authenticate with Bugzilla: `query` sends `?api_key=<KEY>` (default, works with most instances); `bearer` sends `Authorization: ****** (required for Red Hat Bugzilla and similar) |
+| `--bugzilla-auth-mode {query,bearer}` | `BUGZILLA_AUTH_MODE` | `query` | How to authenticate with Bugzilla: `query` sends `?api_key=<KEY>` (default, works with most instances); `bearer` sends `Authorization: Bearer <KEY>` header (required for Red Hat Bugzilla and similar) |
 | `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
 | `--download-dir <DIR>` | `BUGZILLA_DOWNLOAD_DIR` | `<tmpdir>/mcp-bugzilla` | Directory where `download_attachment` writes binary/oversized attachments. The default directory is created on first use and restricted to the owner (`0o700`); an explicit `output_dir` keeps its own permissions |
 
@@ -336,7 +336,7 @@ For MCP clients that launch the server as a subprocess and speak over stdin/stdo
 
 ```bash
 # Authenticated stdio
-BUGZILLA_API_KEY=your_api_key \\
+BUGZILLA_API_KEY=your_api_key \
   mcp-bugzilla --bugzilla-server https://bugzilla.opensuse.org --transport stdio
 
 # Anonymous stdio (public Bugzilla instances)
@@ -377,9 +377,9 @@ If the client omits the `ApiKey` header, the server falls back to the `--bugzill
 
 **Example with curl**:
 ```bash
-curl -X POST http://127.0.0.1:8000/mcp/ \\
-  -H "ApiKey: YOUR_API_KEY_HERE" \\
-  -H "Content-Type: application/json" \\
+curl -X POST http://127.0.0.1:8000/mcp/ \
+  -H "ApiKey: YOUR_API_KEY_HERE" \
+  -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "server_url_resource"}, "id": 1}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ The `mcp-bugzilla` command supports the following options:
 | `--transport {http,stdio}` | `MCP_TRANSPORT` | `http` | Transport for the MCP server. `stdio` is for direct subprocess launches by an MCP client; `http` exposes a network endpoint |
 | `--host <ADDRESS>` | `MCP_HOST` | `127.0.0.1` | Host address for the MCP server to listen on (http transport only) |
 | `--port <PORT>` | `MCP_PORT` | `8000` | Port for the MCP server to listen on (http transport only) |
-| `--mcp-auth-header <HEADER>` | `MCP_AUTH_HEADER` | `ApiKey` | HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). If the client omits this header, access falls back to `--bugzilla-api-key` or is anonymous |
+| `--mcp-auth-header <HEADER>` | `MCP_AUTH_HEADER` | *none* | HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). When not specified, inbound header authentication is disabled and client headers are ignored. |
 | `--bugzilla-api-key <KEY>` | `BUGZILLA_API_KEY` | *none* | Static Bugzilla API key. Optional: if omitted and not provided per-request via `--mcp-auth-header` (http), access is **anonymous**. For `--transport stdio` this is the only source of the key |
 | `--bugzilla-auth-mode {query,bearer}` | `BUGZILLA_AUTH_MODE` | `query` | How to authenticate with Bugzilla: `query` sends `?api_key=<KEY>` (default, works with most instances); `bearer` sends `Authorization: Bearer <KEY>` header (required for Red Hat Bugzilla and similar) |
 | `--read-only` | `MCP_READ_ONLY` | `False` | Disables all tools which can modify a bug. Works well in conjunction with `MCP_BUGZILLA_DISABLED_METHODS` |
@@ -364,7 +364,7 @@ Authentication is **optional**. If no API key is provided, the server accesses B
 
 #### Sending the API key from the MCP client (http transport)
 
-Include the Bugzilla API key in the HTTP request header sent to this MCP server. By default, the header name is `ApiKey` (configurable via `--mcp-auth-header` / `MCP_AUTH_HEADER`):
+Include the Bugzilla API key in the HTTP request header sent to this MCP server. To enable inbound header authentication, you must specify the header name using `--mcp-auth-header <HEADER>` (e.g., `--mcp-auth-header ApiKey`) or configure it via the `MCP_AUTH_HEADER` environment variable (e.g., `MCP_AUTH_HEADER=ApiKey`). If not configured, any inbound client headers are ignored:
 
 ```http
 POST /mcp/ HTTP/1.1
@@ -373,7 +373,7 @@ ApiKey: YOUR_API_KEY_HERE
 Content-Type: application/json
 ```
 
-If the client omits the `ApiKey` header, the server falls back to the `--bugzilla-api-key` / `BUGZILLA_API_KEY` static key, or uses anonymous access if that is also unset.
+If the client omits this header (or if inbound header authentication is disabled), the server falls back to the `--bugzilla-api-key` / `BUGZILLA_API_KEY` static key, or uses anonymous access if that is also unset.
 
 **Example with curl**:
 ```bash
@@ -601,7 +601,7 @@ mcp-bugzilla --bugzilla-server https://bugzilla.example.com
 **Issue**: Receiving 401 Unauthorized from Bugzilla
 
 **Solution**: 
-1. Ensure you're sending the API key in the correct HTTP header to the MCP server (default: `ApiKey`, or configure with `--mcp-auth-header`)
+1. Ensure you have enabled inbound header authentication (e.g., via `--mcp-auth-header ApiKey` or `MCP_AUTH_HEADER=ApiKey`) and that you're sending the API key in the correct HTTP header.
 2. Verify the API key is valid and not expired
 3. Check that `--bugzilla-auth-mode` matches what the Bugzilla instance expects (`query` for standard instances, `bearer` for Red Hat Bugzilla)
 

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -35,8 +35,8 @@ def main():
     parser.add_argument(
         "--mcp-auth-header",
         type=str,
-        default=os.getenv("MCP_AUTH_HEADER", "ApiKey"),
-        help="HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). Defaults to 'ApiKey' or MCP_AUTH_HEADER environment variable. Replaces --api-key-header.",
+        default=os.getenv("MCP_AUTH_HEADER"),
+        help="HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). Defaults to MCP_AUTH_HEADER environment variable. If neither is set, inbound header authentication is disabled. Replaces --api-key-header.",
     )
 
     # --- Outbound auth: MCP -> Bugzilla ---

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -30,17 +30,48 @@ def main():
         default=int(os.getenv("MCP_PORT", "8000")),
         help="Port for the MCP server to listen on, Defaults to 8000 or MCP_PORT environment variable.",
     )
+
+    # --- Inbound auth: client -> MCP ---
+    parser.add_argument(
+        "--mcp-auth-header",
+        type=str,
+        default=os.getenv("MCP_AUTH_HEADER", "ApiKey"),
+        help="HTTP header name that clients use to send the Bugzilla API key to this MCP server (http transport only). Defaults to 'ApiKey' or MCP_AUTH_HEADER environment variable. Replaces --api-key-header.",
+    )
+
+    # --- Outbound auth: MCP -> Bugzilla ---
+    parser.add_argument(
+        "--bugzilla-api-key",
+        type=str,
+        default=os.getenv("BUGZILLA_API_KEY"),
+        help="Bugzilla API key. If omitted (and not provided per-request via --mcp-auth-header for http transport), Bugzilla access is anonymous. For --transport stdio this is the only source of the key. Environment variable BUGZILLA_API_KEY can also be used. Replaces --api-key.",
+    )
+    parser.add_argument(
+        "--bugzilla-auth-mode",
+        type=str,
+        choices=["query", "bearer"],
+        default=os.getenv("BUGZILLA_AUTH_MODE", "query"),
+        help="How to authenticate with Bugzilla: 'query' (default) sends the API key as the api_key query parameter; 'bearer' sends it as an Authorization: ****** (required for some Bugzilla instances such as Red Hat Bugzilla). Environment variable BUGZILLA_AUTH_MODE can also be used. Replaces --use-auth-header.",
+    )
+
+    # --- Deprecated args kept for backward compatibility ---
+    # TODO: Remove deprecated args when deprecation period expires.
     parser.add_argument(
         "--api-key-header",
         type=str,
-        default=os.getenv("MCP_API_KEY_HEADER", "ApiKey"),
-        help="HTTP header for clients to send the Bugzilla API key. Defaults to 'ApiKey' or MCP_API_KEY_HEADER environment variable.",
+        default=os.getenv("MCP_API_KEY_HEADER"),
+        help="[DEPRECATED] Use --mcp-auth-header / MCP_AUTH_HEADER instead.",
     )
-
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="[DEPRECATED] Use --bugzilla-api-key / BUGZILLA_API_KEY instead.",
+    )
     parser.add_argument(
         "--use-auth-header",
         action="store_true",
-        help="Use Authorization: Bearer header instead of api_key query parameter (required for some Bugzilla instances)",
+        help="[DEPRECATED] Use --bugzilla-auth-mode bearer instead.",
     )
 
     parser.add_argument(
@@ -58,12 +89,6 @@ def main():
         help="Transport for the MCP server: 'http' (default) or 'stdio'. Environment variable MCP_TRANSPORT can also be used.",
     )
 
-    parser.add_argument(
-        "--api-key",
-        type=str,
-        default=os.getenv("BUGZILLA_API_KEY"),
-        help="Bugzilla API key. Required for --transport stdio (no HTTP headers exist there). Environment variable BUGZILLA_API_KEY can also be used. Ignored for --transport http (clients send the key per-request via the API key header).",
-    )
     parser.add_argument(
         "--download-dir",
         type=str,
@@ -83,8 +108,37 @@ def main():
         )
         sys.exit(1)
 
-    # Stdio transport has no HTTP request scope, so --host/--port are meaningless
-    # and the API key must be provided up-front (env var or CLI flag).
+    # TODO: Remove deprecated arg handling when deprecation period expires.
+    # Map deprecated args to their replacements, with a visible warning.
+    _new_auth_header_set = os.getenv("MCP_AUTH_HEADER") or any(
+        tok == "--mcp-auth-header" or tok.startswith("--mcp-auth-header=")
+        for tok in sys.argv[1:]
+    )
+    if args.api_key_header is not None:
+        mcp_log.warning(
+            "--api-key-header / MCP_API_KEY_HEADER is deprecated; "
+            "use --mcp-auth-header / MCP_AUTH_HEADER instead."
+        )
+        if not _new_auth_header_set:
+            args.mcp_auth_header = args.api_key_header
+
+    if args.api_key is not None:
+        mcp_log.warning(
+            "--api-key is deprecated; "
+            "use --bugzilla-api-key / BUGZILLA_API_KEY instead."
+        )
+        if args.bugzilla_api_key is None:
+            args.bugzilla_api_key = args.api_key
+
+    if args.use_auth_header:
+        mcp_log.warning(
+            "--use-auth-header is deprecated; "
+            "use --bugzilla-auth-mode bearer instead."
+        )
+        if args.bugzilla_auth_mode == "query":
+            args.bugzilla_auth_mode = "bearer"
+
+    # Stdio transport has no HTTP request scope, so --host/--port are meaningless.
     # We sniff sys.argv because argparse can't natively tell a default value from
     # an explicit pass (env-var defaults muddy the comparison further).
     if args.transport == "stdio":
@@ -97,19 +151,6 @@ def main():
         )
         if explicit_host_or_port:
             parser.error("--host/--port are not valid with --transport stdio")
-        if not args.api_key:
-            parser.error(
-                "--transport stdio requires --api-key or the BUGZILLA_API_KEY environment variable"
-            )
-    elif args.transport == "http" and args.api_key:
-        # In http mode the server takes the API key from each client's per-request
-        # header; the startup-time --api-key / BUGZILLA_API_KEY is unused. Warn so
-        # the user cleans the config and doesn't think they're authenticating.
-        mcp_log.warning(
-            "--api-key / BUGZILLA_API_KEY is set but ignored with --transport http "
-            "(clients send the key per-request via the API key header). "
-            "Unset it to clean the config."
-        )
 
     server.cli_args = args
     server.start()

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -108,6 +108,12 @@ def main():
         )
         sys.exit(1)
 
+    if args.bugzilla_auth_mode not in ["query", "bearer"]:
+        mcp_log.critical(
+            f"Error: Invalid --bugzilla-auth-mode '{args.bugzilla_auth_mode}'. Must be 'query' or 'bearer'. Exiting."
+        )
+        sys.exit(1)
+
     # TODO: Remove deprecated arg handling when deprecation period expires.
     # Map deprecated args to their replacements, with a visible warning.
     _new_auth_header_set = os.getenv("MCP_AUTH_HEADER") or any(

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -51,7 +51,7 @@ def main():
         type=str,
         choices=["query", "bearer"],
         default=os.getenv("BUGZILLA_AUTH_MODE", "query"),
-        help="How to authenticate with Bugzilla: 'query' (default) sends the API key as the api_key query parameter; 'bearer' sends it as an Authorization: ****** (required for some Bugzilla instances such as Red Hat Bugzilla). Environment variable BUGZILLA_AUTH_MODE can also be used. Replaces --use-auth-header.",
+        help="How to authenticate with Bugzilla: 'query' (default) sends the API key as the api_key query parameter; 'bearer' sends it as an Authorization: Bearer <KEY> header (required for some Bugzilla instances such as Red Hat Bugzilla). Environment variable BUGZILLA_AUTH_MODE can also be used. Replaces --use-auth-header.",
     )
 
     # --- Deprecated args kept for backward compatibility ---

--- a/src/mcp_bugzilla/__init__.py
+++ b/src/mcp_bugzilla/__init__.py
@@ -132,8 +132,7 @@ def main():
 
     if args.use_auth_header:
         mcp_log.warning(
-            "--use-auth-header is deprecated; "
-            "use --bugzilla-auth-mode bearer instead."
+            "--use-auth-header is deprecated; use --bugzilla-auth-mode bearer instead."
         )
         if args.bugzilla_auth_mode == "query":
             args.bugzilla_auth_mode = "bearer"

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -84,16 +84,19 @@ def _bugzilla_error_body(response: httpx.Response) -> Optional[dict[str, Any]]:
 class Bugzilla:
     """Async Bugzilla API client"""
 
-    def __init__(self, url: str, api_key: str, use_auth_header: bool = False):
+    def __init__(self, url: str, api_key: str = "", use_auth_header: bool = False):
         self.base_url = url.rstrip("/")
         self.api_url = f"{self.base_url}/rest"
         self.api_key = api_key
         params = {}
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        if use_auth_header:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        else:
-            params["api_key"] = self.api_key
+        # Only attach auth credentials when a non-empty key is provided;
+        # an empty key means anonymous access (no api_key param or Authorization header).
+        if api_key:
+            if use_auth_header:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+            else:
+                params["api_key"] = api_key
         # We'll use a single client for the instance
         self.client = httpx.AsyncClient(
             base_url=self.api_url,
@@ -105,11 +108,6 @@ class Bugzilla:
 
     async def close(self):
         await self.client.aclose()
-
-    @property
-    def params(self) -> dict[str, Any]:
-        """Return params (mainly for read access if needed externally)"""
-        return {"api_key": self.api_key}
 
     async def server_version(self) -> str:
         """Fetch bugzilla server version"""

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -51,32 +51,38 @@ MAX_FORCED_INLINE_BYTES: int = 1024 * 1024
 async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
     """Dependency to get the current Bugzilla client.
 
-    For http transport, the API key is read per-request from the configured header.
-    For stdio transport, there is no HTTP request scope, so the key comes from
-    the CLI flag / BUGZILLA_API_KEY env var captured at startup.
+    For http transport, the API key is read per-request from the configured header
+    (--mcp-auth-header / MCP_AUTH_HEADER); if absent, falls back to the static
+    --bugzilla-api-key / BUGZILLA_API_KEY value.
+    For stdio transport, there is no HTTP request scope, so the key comes only
+    from --bugzilla-api-key / BUGZILLA_API_KEY captured at startup.
+    If no non-empty key is found from any source, access is anonymous.
     """
     mcp_log.debug("api_key: Checking")
 
     transport = getattr(cli_args, "transport", "http")
 
     if transport == "stdio":
-        api_key_value = getattr(cli_args, "api_key", None)
-        if not api_key_value:
-            # Defense in depth; main() already validates this at startup.
-            raise ValidationError(
-                "stdio transport requires --api-key or BUGZILLA_API_KEY env var"
-            )
+        # Static key only; anonymous if unset.
+        api_key_value = getattr(cli_args, "bugzilla_api_key", None) or ""
     else:
-        api_key_header = getattr(cli_args, "api_key_header", "ApiKey")
-        api_key_value = headers.get(api_key_header.lower())
+        # Per-request header is the primary source for http transport.
+        mcp_auth_header = getattr(cli_args, "mcp_auth_header", "ApiKey")
+        api_key_value = headers.get(mcp_auth_header.lower()) or ""
+        # Fall back to the static key if the client did not send one.
         if not api_key_value:
-            raise ValidationError(f"`{api_key_header}` header is required")
+            api_key_value = getattr(cli_args, "bugzilla_api_key", None) or ""
 
-    mcp_log.debug("api_key: Found")
+    if api_key_value:
+        mcp_log.debug("api_key: Found")
+    else:
+        mcp_log.debug("api_key: Not provided — using anonymous access")
+
+    use_bearer = getattr(cli_args, "bugzilla_auth_mode", "query") == "bearer"
     bz = Bugzilla(
         url=base_url,
         api_key=api_key_value,
-        use_auth_header=getattr(cli_args, "use_auth_header", False),
+        use_auth_header=use_bearer,
     )
     try:
         yield bz

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -66,9 +66,12 @@ async def get_bz(headers: dict = CurrentHeaders()) -> Bugzilla:
         # Static key only; anonymous if unset.
         api_key_value = getattr(cli_args, "bugzilla_api_key", None) or ""
     else:
-        # Per-request header is the primary source for http transport.
-        mcp_auth_header = getattr(cli_args, "mcp_auth_header", "ApiKey")
-        api_key_value = headers.get(mcp_auth_header.lower()) or ""
+        # Per-request header is the primary source for http transport if set.
+        mcp_auth_header = getattr(cli_args, "mcp_auth_header", None)
+        if mcp_auth_header:
+            api_key_value = headers.get(mcp_auth_header.lower()) or ""
+        else:
+            api_key_value = ""
         # Fall back to the static key if the client did not send one.
         if not api_key_value:
             api_key_value = getattr(cli_args, "bugzilla_api_key", None) or ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ def _run_main(monkeypatch, argv, env=None):
 # Deprecated --api-key behaviour
 # ---------------------------------------------------------------------------
 
+
 def test_deprecated_api_key_http_warns_and_starts(monkeypatch, captured_mcp_log):
     """Using the deprecated --api-key flag must emit a deprecation warning."""
     mock_start = _run_main(
@@ -88,7 +89,8 @@ def test_new_bugzilla_api_key_http_no_warning(monkeypatch, captured_mcp_log):
     )
     mock_start.assert_called_once()
     deprecation_warnings = [
-        r for r in captured_mcp_log.records
+        r
+        for r in captured_mcp_log.records
         if r.levelno == logging.WARNING and "deprecated" in r.message.lower()
     ]
     assert deprecation_warnings == [], (
@@ -111,7 +113,9 @@ def test_deprecated_api_key_header_warns(monkeypatch, captured_mcp_log):
     )
     mock_start.assert_called_once()
     warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
-    assert any("--api-key-header" in r.message and "deprecated" in r.message for r in warnings), (
+    assert any(
+        "--api-key-header" in r.message and "deprecated" in r.message for r in warnings
+    ), (
         f"Expected --api-key-header deprecation warning, got: {[r.message for r in warnings]}"
     )
 
@@ -130,7 +134,9 @@ def test_deprecated_use_auth_header_warns(monkeypatch, captured_mcp_log):
     )
     mock_start.assert_called_once()
     warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
-    assert any("--use-auth-header" in r.message and "deprecated" in r.message for r in warnings), (
+    assert any(
+        "--use-auth-header" in r.message and "deprecated" in r.message for r in warnings
+    ), (
         f"Expected --use-auth-header deprecation warning, got: {[r.message for r in warnings]}"
     )
 
@@ -144,7 +150,9 @@ def test_deprecated_env_api_key_header_warns(monkeypatch, captured_mcp_log):
     )
     mock_start.assert_called_once()
     warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
-    assert any("--api-key-header" in r.message and "deprecated" in r.message for r in warnings), (
+    assert any(
+        "--api-key-header" in r.message and "deprecated" in r.message for r in warnings
+    ), (
         f"Expected MCP_API_KEY_HEADER deprecation warning, got: {[r.message for r in warnings]}"
     )
 
@@ -152,6 +160,7 @@ def test_deprecated_env_api_key_header_warns(monkeypatch, captured_mcp_log):
 # ---------------------------------------------------------------------------
 # Anonymous access (no key required)
 # ---------------------------------------------------------------------------
+
 
 def test_http_transport_without_any_key_starts(monkeypatch, captured_mcp_log):
     """http transport without any API key must start (anonymous access)."""
@@ -175,6 +184,7 @@ def test_stdio_transport_without_api_key_starts(monkeypatch, captured_mcp_log):
 # stdio + --host/--port rejection
 # ---------------------------------------------------------------------------
 
+
 def test_stdio_transport_with_host_exits(monkeypatch):
     monkeypatch.setattr(
         "sys.argv",
@@ -188,7 +198,12 @@ def test_stdio_transport_with_host_exits(monkeypatch):
             "0.0.0.0",
         ],
     )
-    for var in ("BUGZILLA_API_KEY", "MCP_TRANSPORT", "MCP_AUTH_HEADER", "MCP_API_KEY_HEADER"):
+    for var in (
+        "BUGZILLA_API_KEY",
+        "MCP_TRANSPORT",
+        "MCP_AUTH_HEADER",
+        "MCP_API_KEY_HEADER",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     with patch("mcp_bugzilla.server.start") as mock_start, pytest.raises(SystemExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,7 @@ def test_stdio_transport_with_host_exits(monkeypatch):
 def test_mcp_auth_header_defaults_to_none_when_omitted(monkeypatch):
     """If --mcp-auth-header is omitted and env var is not set, it should default to None."""
     from mcp_bugzilla import server
+
     _run_main(
         monkeypatch,
         ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
@@ -226,12 +227,18 @@ def test_invalid_bugzilla_auth_mode_env_exits(monkeypatch, captured_mcp_log):
     with pytest.raises(SystemExit) as exc_info:
         _run_main(
             monkeypatch,
-            ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
+            [
+                "--bugzilla-server",
+                "https://bugzilla.example.com",
+                "--transport",
+                "http",
+            ],
             env={"BUGZILLA_AUTH_MODE": "invalid_mode"},
         )
     assert exc_info.value.code == 1
-    critical_logs = [r for r in captured_mcp_log.records if r.levelno == logging.CRITICAL]
+    critical_logs = [
+        r for r in captured_mcp_log.records if r.levelno == logging.CRITICAL
+    ]
     assert any("Invalid --bugzilla-auth-mode" in r.message for r in critical_logs), (
         f"Expected critical log for invalid bugzilla-auth-mode, got: {[r.message for r in critical_logs]}"
     )
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,3 +204,19 @@ def test_mcp_auth_header_defaults_to_none_when_omitted(monkeypatch):
         ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
     )
     assert server.cli_args.mcp_auth_header is None
+
+
+def test_invalid_bugzilla_auth_mode_env_exits(monkeypatch, captured_mcp_log):
+    """If BUGZILLA_AUTH_MODE env var has an invalid value, main() must log a critical error and exit."""
+    with pytest.raises(SystemExit) as exc_info:
+        _run_main(
+            monkeypatch,
+            ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
+            env={"BUGZILLA_AUTH_MODE": "invalid_mode"},
+        )
+    assert exc_info.value.code == 1
+    critical_logs = [r for r in captured_mcp_log.records if r.levelno == logging.CRITICAL]
+    assert any("Invalid --bugzilla-auth-mode" in r.message for r in critical_logs), (
+        f"Expected critical log for invalid bugzilla-auth-mode, got: {[r.message for r in critical_logs]}"
+    )
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,9 @@ def _run_main(monkeypatch, argv, env=None):
         "MCP_PORT",
         "MCP_TRANSPORT",
         "MCP_READ_ONLY",
+        "MCP_AUTH_HEADER",
         "MCP_API_KEY_HEADER",
+        "BUGZILLA_AUTH_MODE",
     ):
         monkeypatch.delenv(var, raising=False)
     for k, v in (env or {}).items():
@@ -47,7 +49,12 @@ def _run_main(monkeypatch, argv, env=None):
     return mock_start
 
 
-def test_http_transport_with_api_key_warns_but_starts(monkeypatch, captured_mcp_log):
+# ---------------------------------------------------------------------------
+# Deprecated --api-key behaviour
+# ---------------------------------------------------------------------------
+
+def test_deprecated_api_key_http_warns_and_starts(monkeypatch, captured_mcp_log):
+    """Using the deprecated --api-key flag must emit a deprecation warning."""
     mock_start = _run_main(
         monkeypatch,
         [
@@ -56,17 +63,18 @@ def test_http_transport_with_api_key_warns_but_starts(monkeypatch, captured_mcp_
             "--transport",
             "http",
             "--api-key",
-            "leftover-key",
+            "legacy-key",
         ],
     )
     mock_start.assert_called_once()
     warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
-    assert any("ignored with --transport http" in r.message for r in warnings), (
-        f"Expected http+api_key warning, got: {[r.message for r in warnings]}"
+    assert any("--api-key is deprecated" in r.message for r in warnings), (
+        f"Expected --api-key deprecation warning, got: {[r.message for r in warnings]}"
     )
 
 
-def test_http_transport_without_api_key_does_not_warn(monkeypatch, captured_mcp_log):
+def test_new_bugzilla_api_key_http_no_warning(monkeypatch, captured_mcp_log):
+    """Using the new --bugzilla-api-key must NOT emit a deprecation warning."""
     mock_start = _run_main(
         monkeypatch,
         [
@@ -74,21 +82,22 @@ def test_http_transport_without_api_key_does_not_warn(monkeypatch, captured_mcp_
             "https://bugzilla.example.com",
             "--transport",
             "http",
+            "--bugzilla-api-key",
+            "new-key",
         ],
     )
     mock_start.assert_called_once()
-    warnings = [
-        r
-        for r in captured_mcp_log.records
-        if r.levelno == logging.WARNING and "ignored with --transport http" in r.message
+    deprecation_warnings = [
+        r for r in captured_mcp_log.records
+        if r.levelno == logging.WARNING and "deprecated" in r.message.lower()
     ]
-    assert warnings == [], (
-        f"Did not expect a warning, got: {[r.message for r in warnings]}"
+    assert deprecation_warnings == [], (
+        f"Did not expect deprecation warning, got: {[r.message for r in deprecation_warnings]}"
     )
 
 
-def test_http_transport_with_env_api_key_warns(monkeypatch, captured_mcp_log):
-    """The warning must also fire when api_key comes from BUGZILLA_API_KEY env var."""
+def test_deprecated_api_key_header_warns(monkeypatch, captured_mcp_log):
+    """Using the deprecated --api-key-header flag must emit a deprecation warning."""
     mock_start = _run_main(
         monkeypatch,
         [
@@ -96,40 +105,77 @@ def test_http_transport_with_env_api_key_warns(monkeypatch, captured_mcp_log):
             "https://bugzilla.example.com",
             "--transport",
             "http",
+            "--api-key-header",
+            "X-Legacy-Key",
         ],
-        env={"BUGZILLA_API_KEY": "from-env"},
     )
     mock_start.assert_called_once()
     warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
-    assert any("ignored with --transport http" in r.message for r in warnings), (
-        f"Expected http+api_key warning, got: {[r.message for r in warnings]}"
+    assert any("--api-key-header" in r.message and "deprecated" in r.message for r in warnings), (
+        f"Expected --api-key-header deprecation warning, got: {[r.message for r in warnings]}"
     )
 
 
-def test_stdio_transport_with_api_key_does_not_warn(monkeypatch, captured_mcp_log):
+def test_deprecated_use_auth_header_warns(monkeypatch, captured_mcp_log):
+    """Using the deprecated --use-auth-header flag must emit a deprecation warning."""
     mock_start = _run_main(
         monkeypatch,
         [
             "--bugzilla-server",
             "https://bugzilla.example.com",
             "--transport",
-            "stdio",
-            "--api-key",
-            "k",
+            "http",
+            "--use-auth-header",
         ],
     )
     mock_start.assert_called_once()
-    warnings = [
-        r
-        for r in captured_mcp_log.records
-        if r.levelno == logging.WARNING and "ignored with --transport http" in r.message
-    ]
-    assert warnings == [], (
-        f"Did not expect http warning in stdio mode, got: {[r.message for r in warnings]}"
+    warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
+    assert any("--use-auth-header" in r.message and "deprecated" in r.message for r in warnings), (
+        f"Expected --use-auth-header deprecation warning, got: {[r.message for r in warnings]}"
     )
 
 
-def test_stdio_transport_without_api_key_exits(monkeypatch):
+def test_deprecated_env_api_key_header_warns(monkeypatch, captured_mcp_log):
+    """MCP_API_KEY_HEADER env var (deprecated) must also emit a deprecation warning."""
+    mock_start = _run_main(
+        monkeypatch,
+        ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
+        env={"MCP_API_KEY_HEADER": "X-Legacy-Key"},
+    )
+    mock_start.assert_called_once()
+    warnings = [r for r in captured_mcp_log.records if r.levelno == logging.WARNING]
+    assert any("--api-key-header" in r.message and "deprecated" in r.message for r in warnings), (
+        f"Expected MCP_API_KEY_HEADER deprecation warning, got: {[r.message for r in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anonymous access (no key required)
+# ---------------------------------------------------------------------------
+
+def test_http_transport_without_any_key_starts(monkeypatch, captured_mcp_log):
+    """http transport without any API key must start (anonymous access)."""
+    mock_start = _run_main(
+        monkeypatch,
+        ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
+    )
+    mock_start.assert_called_once()
+
+
+def test_stdio_transport_without_api_key_starts(monkeypatch, captured_mcp_log):
+    """stdio transport without any API key must start (anonymous access)."""
+    mock_start = _run_main(
+        monkeypatch,
+        ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "stdio"],
+    )
+    mock_start.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# stdio + --host/--port rejection
+# ---------------------------------------------------------------------------
+
+def test_stdio_transport_with_host_exits(monkeypatch):
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -138,9 +184,11 @@ def test_stdio_transport_without_api_key_exits(monkeypatch):
             "https://bugzilla.example.com",
             "--transport",
             "stdio",
+            "--host",
+            "0.0.0.0",
         ],
     )
-    for var in ("BUGZILLA_API_KEY", "MCP_TRANSPORT"):
+    for var in ("BUGZILLA_API_KEY", "MCP_TRANSPORT", "MCP_AUTH_HEADER", "MCP_API_KEY_HEADER"):
         monkeypatch.delenv(var, raising=False)
 
     with patch("mcp_bugzilla.server.start") as mock_start, pytest.raises(SystemExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,3 +194,13 @@ def test_stdio_transport_with_host_exits(monkeypatch):
     with patch("mcp_bugzilla.server.start") as mock_start, pytest.raises(SystemExit):
         main()
     mock_start.assert_not_called()
+
+
+def test_mcp_auth_header_defaults_to_none_when_omitted(monkeypatch):
+    """If --mcp-auth-header is omitted and env var is not set, it should default to None."""
+    from mcp_bugzilla import server
+    _run_main(
+        monkeypatch,
+        ["--bugzilla-server", "https://bugzilla.example.com", "--transport", "http"],
+    )
+    assert server.cli_args.mcp_auth_header is None

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -674,6 +674,7 @@ def test_safe_filename(name, expected):
 # Anonymous client (empty api_key)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_anonymous_client_sends_no_api_key_param():
     """A Bugzilla client created with an empty key must not send the api_key param."""

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -668,3 +668,63 @@ def test_is_textual(content_type, expected):
 )
 def test_safe_filename(name, expected):
     assert safe_filename(name, 7) == expected
+
+
+# ---------------------------------------------------------------------------
+# Anonymous client (empty api_key)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_anonymous_client_sends_no_api_key_param():
+    """A Bugzilla client created with an empty key must not send the api_key param."""
+    anon = Bugzilla(MOCK_URL, api_key="")
+    try:
+        async with respx.mock(base_url=MOCK_URL) as respx_mock:
+            route = respx_mock.get("/rest/bug/1").mock(
+                return_value=Response(200, json={"bugs": [{"id": 1}]})
+            )
+            await anon.bug_info({1})
+            assert "api_key" not in route.calls.last.request.url.params
+    finally:
+        await anon.close()
+
+
+@pytest.mark.asyncio
+async def test_anonymous_client_sends_no_auth_header():
+    """A Bugzilla client created with an empty key must not send Authorization header."""
+    anon = Bugzilla(MOCK_URL, api_key="")
+    try:
+        assert "Authorization" not in anon.client.headers
+    finally:
+        await anon.close()
+
+
+@pytest.mark.asyncio
+async def test_authenticated_client_sends_api_key_param():
+    """A Bugzilla client with a non-empty key must send api_key as query param by default."""
+    client = Bugzilla(MOCK_URL, api_key="mykey")
+    try:
+        async with respx.mock(base_url=MOCK_URL) as respx_mock:
+            route = respx_mock.get("/rest/bug/1").mock(
+                return_value=Response(200, json={"bugs": [{"id": 1}]})
+            )
+            await client.bug_info({1})
+            assert route.calls.last.request.url.params["api_key"] == "mykey"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_bearer_client_sends_auth_header_not_param():
+    """A Bugzilla client in bearer mode must send Authorization header, not api_key param."""
+    client = Bugzilla(MOCK_URL, api_key="bearerkey", use_auth_header=True)
+    try:
+        async with respx.mock(base_url=MOCK_URL) as respx_mock:
+            route = respx_mock.get("/rest/bug/1").mock(
+                return_value=Response(200, json={"bugs": [{"id": 1}]})
+            )
+            await client.bug_info({1})
+            assert "api_key" not in route.calls.last.request.url.params
+            assert "authorization" in dict(route.calls.last.request.headers)
+    finally:
+        await client.close()

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -14,18 +14,23 @@ def _base_args(**overrides):
         bugzilla_server="https://bugzilla.example.com",
         host="127.0.0.1",
         port=8000,
-        api_key_header="ApiKey",
+        # New primary auth args
+        mcp_auth_header="ApiKey",
+        bugzilla_api_key=None,
+        bugzilla_auth_mode="query",
+        # Deprecated args kept for backward compatibility
+        api_key_header=None,
         use_auth_header=False,
+        api_key=None,
         read_only=False,
         transport="http",
-        api_key=None,
     )
     defaults.update(overrides)
     return Namespace(**defaults)
 
 
 def test_stdio_transport_invokes_mcp_run_stdio():
-    server.cli_args = _base_args(transport="stdio", api_key="k")
+    server.cli_args = _base_args(transport="stdio", bugzilla_api_key="k")
     with patch.object(server.mcp, "run") as mock_run:
         server.start()
     mock_run.assert_called_once_with(transport="stdio", show_banner=False)
@@ -42,11 +47,9 @@ def test_http_transport_unchanged():
 
 @pytest.mark.asyncio
 async def test_get_bz_uses_cli_api_key_in_stdio_mode():
-    server.cli_args = _base_args(transport="stdio", api_key="from-cli")
-    # Set base_url the way start() would; we skip start() to avoid mcp.run().
+    server.cli_args = _base_args(transport="stdio", bugzilla_api_key="from-cli")
     server.base_url = "https://bugzilla.example.com"
 
-    # In stdio mode, headers are irrelevant; pass an empty dict.
     async with server.get_bz(headers={}) as bz:
         assert bz.api_key == "from-cli"
 
@@ -61,12 +64,43 @@ async def test_get_bz_uses_header_in_http_mode():
 
 
 @pytest.mark.asyncio
-async def test_get_bz_raises_in_stdio_mode_without_key():
-    from fastmcp.exceptions import ValidationError
-
-    server.cli_args = _base_args(transport="stdio", api_key=None)
+async def test_get_bz_falls_back_to_static_key_in_http_mode():
+    """When the per-request header is absent, fall back to --bugzilla-api-key."""
+    server.cli_args = _base_args(transport="http", bugzilla_api_key="static-key")
     server.base_url = "https://bugzilla.example.com"
 
-    with pytest.raises(ValidationError):
-        async with server.get_bz(headers={}):
-            pass
+    async with server.get_bz(headers={}) as bz:
+        assert bz.api_key == "static-key"
+
+
+@pytest.mark.asyncio
+async def test_get_bz_anonymous_http_mode():
+    """No header and no static key → anonymous (empty api_key)."""
+    server.cli_args = _base_args(transport="http")
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={}) as bz:
+        assert bz.api_key == ""
+
+
+@pytest.mark.asyncio
+async def test_get_bz_anonymous_stdio_mode():
+    """No --bugzilla-api-key in stdio → anonymous (empty api_key)."""
+    server.cli_args = _base_args(transport="stdio", bugzilla_api_key=None)
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={}) as bz:
+        assert bz.api_key == ""
+
+
+@pytest.mark.asyncio
+async def test_get_bz_bearer_auth_mode():
+    """--bugzilla-auth-mode bearer is passed through to the Bugzilla client."""
+    server.cli_args = _base_args(transport="stdio", bugzilla_api_key="k", bugzilla_auth_mode="bearer")
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={}) as bz:
+        assert bz.api_key == "k"
+        # bearer mode: Authorization header set, no api_key query param
+        assert "Authorization" in bz.client.headers
+        assert "api_key" not in bz.client.params

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -96,7 +96,9 @@ async def test_get_bz_anonymous_stdio_mode():
 @pytest.mark.asyncio
 async def test_get_bz_bearer_auth_mode():
     """--bugzilla-auth-mode bearer is passed through to the Bugzilla client."""
-    server.cli_args = _base_args(transport="stdio", bugzilla_api_key="k", bugzilla_auth_mode="bearer")
+    server.cli_args = _base_args(
+        transport="stdio", bugzilla_api_key="k", bugzilla_auth_mode="bearer"
+    )
     server.base_url = "https://bugzilla.example.com"
 
     async with server.get_bz(headers={}) as bz:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -64,6 +64,26 @@ async def test_get_bz_uses_header_in_http_mode():
 
 
 @pytest.mark.asyncio
+async def test_get_bz_ignores_header_when_mcp_auth_header_is_none():
+    """When mcp_auth_header is None (i.e. disabled), any client headers should be ignored."""
+    server.cli_args = _base_args(transport="http", mcp_auth_header=None)
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={"apikey": "should-be-ignored"}) as bz:
+        assert bz.api_key == ""
+
+
+@pytest.mark.asyncio
+async def test_get_bz_ignores_header_and_falls_back_to_static_key_when_mcp_auth_header_is_none():
+    """When mcp_auth_header is None (i.e. disabled), any client headers should be ignored, and we fall back to static key."""
+    server.cli_args = _base_args(transport="http", mcp_auth_header=None, bugzilla_api_key="static-key")
+    server.base_url = "https://bugzilla.example.com"
+
+    async with server.get_bz(headers={"apikey": "should-be-ignored"}) as bz:
+        assert bz.api_key == "static-key"
+
+
+@pytest.mark.asyncio
 async def test_get_bz_falls_back_to_static_key_in_http_mode():
     """When the per-request header is absent, fall back to --bugzilla-api-key."""
     server.cli_args = _base_args(transport="http", bugzilla_api_key="static-key")

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -76,7 +76,9 @@ async def test_get_bz_ignores_header_when_mcp_auth_header_is_none():
 @pytest.mark.asyncio
 async def test_get_bz_ignores_header_and_falls_back_to_static_key_when_mcp_auth_header_is_none():
     """When mcp_auth_header is None (i.e. disabled), any client headers should be ignored, and we fall back to static key."""
-    server.cli_args = _base_args(transport="http", mcp_auth_header=None, bugzilla_api_key="static-key")
+    server.cli_args = _base_args(
+        transport="http", mcp_auth_header=None, bugzilla_api_key="static-key"
+    )
     server.base_url = "https://bugzilla.example.com"
 
     async with server.get_bz(headers={"apikey": "should-be-ignored"}) as bz:


### PR DESCRIPTION
The auth-related CLI flags conflated client→MCP and MCP→Bugzilla concerns under non-obvious names, and hard-required an API key even for public Bugzilla instances that support anonymous REST access.

## New parameters

| New arg | Env var | Replaces | Notes |
|---------|---------|----------|-------|
| `--mcp-auth-header` | `MCP_AUTH_HEADER` | `--api-key-header` / `MCP_API_KEY_HEADER` | Header clients send to *this server* (http only) |
| `--bugzilla-api-key` | `BUGZILLA_API_KEY` | `--api-key` | Static key forwarded to Bugzilla; **optional** — anonymous if absent |
| `--bugzilla-auth-mode {query,bearer}` | `BUGZILLA_AUTH_MODE` | `--use-auth-header` | `query` (default) = `?api_key=…`; `bearer` = `Authorization: ****** |

## Auth logic

- **No key → anonymous**: `Bugzilla.__init__` skips auth params entirely when `api_key=""`.
- **http transport**: per-request header is primary, falls back to `--bugzilla-api-key`, then anonymous.
- **stdio transport**: uses `--bugzilla-api-key` or anonymous — key is no longer required at startup.

## Deprecation

Old flags (`--api-key-header`, `--api-key`, `--use-auth-header`) still work and are mapped to the new equivalents, but emit a `WARNING` log entry. Marked with `# TODO: Remove` for cleanup when deprecation expires.

## Tests

10 new tests covering anonymous client (no `api_key` param/header sent), per-request header fallback, deprecated-arg warnings, and bearer mode. Existing transport/CLI tests updated to new arg names.