### PR TITLE
refactor(bugs_quicksearch): remove status field from signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,15 +154,14 @@ The server provides the following tools for interacting with Bugzilla:
 
 #### Bug Search
 
-- **`bugs_quicksearch(query: str, status: str = "ALL", include_fields: str = "...", limit: int = 50, offset: int = 0)`**: Executes a search for bugs using Bugzilla's powerful [quicksearch syntax](https://bugzilla.readthedocs.io/en/latest/using/finding.html#quicksearch).
+- **`bugs_quicksearch(query: str, include_fields: str = "...", limit: int = 50, offset: int = 0)`**: Executes a search for bugs using Bugzilla's powerful [quicksearch syntax](https://bugzilla.readthedocs.io/en/latest/using/finding.html#quicksearch).
   - **Parameters**:
     - `query`: A quicksearch query string (e.g., `"product:Firefox"`)
-    - `status`: Bug status to filter by (default: `"ALL"`)
     - `include_fields`: Comma-separated list of fields to return (default: `"id,product,component,assigned_to,status,resolution,summary,last_change_time"`)
     - `limit`: Maximum number of results to return (default: `50`)
     - `offset`: Number of results to skip for pagination (default: `0`)
   - **Returns**: A list of dictionaries, each containing essential bug fields
-  - **Example**: `bugs_quicksearch("product:Firefox", status="NEW", limit=10)`
+  - **Example**: `bugs_quicksearch("product:Firefox status:NEW", limit=10)`
 
 - **`quicksearch_syntax_resource()`**: Returns documentation on Bugzilla's quicksearch syntax.
   - **Returns**: A string containing HTML documentation.

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -285,14 +285,13 @@ class Bugzilla:
         return data
 
     async def quicksearch(
-        self, query: str, status: str, include_fields: str, limit: int, offset: int
+        self, query: str, include_fields: str, limit: int, offset: int
     ) -> dict[str, Any]:
         """Perform a quicksearch"""
         # Quicksearch isn't a direct REST endpoint usually, but /bug with quicksearch param works
 
-        quicksearch_query = f"{status} {query}" if status else query
         params = {
-            "quicksearch": quicksearch_query,
+            "quicksearch": query,
             "include_fields": include_fields,
             "limit": limit,
             "offset": offset,

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -17,7 +17,7 @@ from typing import Any, List, Literal, Optional, TypedDict, Union
 
 from fastmcp import FastMCP
 from fastmcp.dependencies import CurrentHeaders, Depends
-from fastmcp.exceptions import PromptError, ResourceError, ToolError, ValidationError
+from fastmcp.exceptions import PromptError, ResourceError, ToolError
 
 from .mcp_utils import Bugzilla, is_textual, mcp_log, safe_filename
 
@@ -185,7 +185,6 @@ async def add_comment(
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bugs_quicksearch(
     query: str,
-    status: Optional[str] = "ALL",
     include_fields: Optional[
         str
     ] = "id,product,component,assigned_to,status,resolution,summary,last_change_time",
@@ -201,14 +200,20 @@ async def bugs_quicksearch(
     """
 
     mcp_log.info(
-        f"[LLM-REQ] bugs_quicksearch(query='{query}',status='{status}', include_fields='{include_fields}', limit={limit}, offset={offset})"
+        f"[LLM-REQ] bugs_quicksearch(query='{query}', include_fields='{include_fields}', limit={limit}, offset={offset})"
     )
 
     try:
         # We moved quicksearch logic to mcp_utils
-        envelope = await bz.quicksearch(query, status, include_fields, limit, offset)
+        envelope = await bz.quicksearch(
+            query,
+            include_fields
+            or "id,product,component,assigned_to,status,resolution,summary,last_change_time",
+            limit or 50,
+            offset or 0,
+        )
 
-        mcp_log.info(f"[LLM-RES] Returning quicksearch envelope")
+        mcp_log.info("[LLM-RES] Returning quicksearch envelope")
         return envelope
 
     except Exception as e:

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -327,14 +327,14 @@ async def test_quicksearch(bz_client):
 
         # Test with explicit arguments (mandatory in mcp_utils)
         search_env = await bz_client.quicksearch(
-            "product:Foo", status="ALL", include_fields="id,product", limit=50, offset=0
+            "product:Foo", include_fields="id,product", limit=50, offset=0
         )
         assert len(search_env["bugs"]) == 2
 
         # Verify call arguments
         assert route.called
         params = route.calls.last.request.url.params
-        assert params["quicksearch"] == "ALL product:Foo"
+        assert params["quicksearch"] == "product:Foo"
         assert params["limit"] == "50"
         assert params["offset"] == "0"
         assert "include_fields" in params


### PR DESCRIPTION
The _status_ param in _bugs_quicksearch_ signature often cheats LLMs when running complex queries, so it can easily happen that:

- LLMs pass _status_ both in the query string and as a param, with conflicting values;
- LLMs only pass _status_ in the query string, hence the code assumes for the status param the "ALL" default;
- LLMs only pass _-status=XXX_ in the query string trying to exclude a specific status, which clashes with the "ALL" assumed default for the param;
- ...

Removing the param from the signature, the intent is to let the LLM provide a valid quicksearch query which runs unaltered on BZ 