### PR TITLE
feat(flags): add tools to read, set, and clear bug flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `get_bug_flags` tool and `Bugzilla.bug_flags()` — list a bug's flags with their instance ids (flags are requested explicitly via `include_fields`, since some instances omit them from the default bug view).
+- `update_bug_flag` tool — set, grant, deny, or clear a bug flag (e.g. `needinfo`, `blocker`), by name+requestee or by flag instance id.
+
 ## [v0.18.0] - 2026-07-31
 
 This release is same as previous one but bumped due to premature pypi release 

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -197,6 +197,33 @@ class Bugzilla:
         mcp_log.debug(f"[BZ-RES] {envelope}")
         return envelope
 
+    async def bug_flags(self, bug_id: int) -> list[dict[str, Any]]:
+        """Return the flags currently set on a bug, with their instance ids.
+
+        The default bug view omits flags on some instances (e.g. Red Hat
+        Bugzilla), so we request them explicitly via include_fields.
+        """
+        url = f"/bug/{bug_id}"
+        params = {"include_fields": "id,flags"}
+        mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url} params={params}")
+
+        try:
+            r = await self.client.get(url, params=params)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        bugs = r.json().get("bugs", [])
+        flags = bugs[0].get("flags", []) if bugs else []
+        mcp_log.info(f"[BZ-RES] Retrieved {len(flags)} flags for bug {bug_id}")
+        return flags
+
     async def bug_history(
         self, bug_id: int, new_since: datetime | None = None
     ) -> list[dict[str, Any]]:

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -880,6 +880,96 @@ async def download_attachment(
         raise ToolError(f"Failed to download attachment {attachment_id}\nReason: {e}")
 
 
+@mcp.tool(
+    annotations={"readOnlyHint": True, "openWorldHint": True},
+    tags={"read"},
+)
+async def get_bug_flags(bug_id: int, bz: Bugzilla = _get_bz) -> list[dict[str, Any]]:
+    """List the flags currently set on a bug, with their instance ids.
+
+    Returns each flag's id, name, status, setter, and requestee — the id is
+    what update_bug_flag needs to change or clear a specific flag instance
+    (e.g. to disambiguate when the same flag type is set for several requestees).
+    """
+    mcp_log.info(f"[LLM-REQ] get_bug_flags(bug_id={bug_id})")
+    try:
+        return await bz.bug_flags(bug_id)
+    except Exception as e:  # noqa: BLE001
+        raise ToolError(f"Failed to fetch bug flags\n{e}")
+
+
+@mcp.tool(
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
+    tags={"write"},
+)
+async def update_bug_flag(
+    bug_id: int,
+    status: Literal["?", "+", "-", "X"],
+    name: str | None = None,
+    requestee: str | None = None,
+    flag_id: int | None = None,
+    comment: str = "",
+    bz: Bugzilla = _get_bz,
+) -> dict[str, Any]:
+    """Set, grant, deny, or clear a flag on a bug (e.g. needinfo, blocker).
+
+    A single flag type such as ``needinfo`` may exist several times on one bug
+    (one per requestee), so Bugzilla has two modes and this tool mirrors them:
+
+    - **Set a new flag** — pass ``name`` (and ``requestee`` for requestable
+      flags like needinfo), e.g. name="needinfo", status="?",
+      requestee="user@example.com".
+    - **Change or clear an existing flag** — pass ``flag_id``, the flag
+      *instance* id (not the type id). Get it by calling ``get_bug_flags``
+      first and reading each flag's ``id``. Use status="X" to clear/remove it.
+
+    Args:
+        bug_id: Bug ID to update.
+        status: "?" request, "+" grant, "-" deny, "X" clear/remove.
+        name: Flag type name, when setting a new flag (e.g. "needinfo").
+        requestee: Email of the person the flag is requested from (needinfo etc.).
+        flag_id: Instance id of an existing flag, when changing or clearing it.
+        comment: Optional comment to add with the change.
+    """
+    mcp_log.info(
+        f"[LLM-REQ] update_bug_flag(bug_id={bug_id}, status='{status}', "
+        f"name={name}, requestee={requestee}, flag_id={flag_id})"
+    )
+
+    if flag_id is None and name is None:
+        raise ToolError(
+            "Provide 'name' to set a new flag, or 'flag_id' to change/clear an "
+            "existing one (call bug_info first to get the flag's id)."
+        )
+    if flag_id is not None and name is not None:
+        raise ToolError(
+            "Provide either 'name' (new flag) or 'flag_id' (existing flag), not both."
+        )
+    if name == "needinfo" and status == "?" and not requestee:
+        raise ToolError(
+            "Setting needinfo with status '?' requires a 'requestee' "
+            "(the email of the person the info is requested from)."
+        )
+
+    flag: dict[str, Any] = {"status": status}
+    if flag_id is not None:
+        flag["id"] = flag_id
+    else:
+        flag["name"] = name
+        if requestee:
+            flag["requestee"] = requestee
+
+    try:
+        result = await bz.update_bug(bug_id, {"flags": [flag]}, comment)
+        return result
+    except Exception as e:  # noqa: BLE001
+        raise ToolError(f"Failed to update bug flag\n{e}")
+
+
 def disable_components_selectively():
     """
     Disables MCP components based on environment variables.

--- a/tests/test_mcp_utils.py
+++ b/tests/test_mcp_utils.py
@@ -344,6 +344,51 @@ async def test_quicksearch(bz_client):
 
 
 @pytest.mark.asyncio
+async def test_bug_flags(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.get("/rest/bug/123").mock(
+            return_value=Response(
+                200,
+                json={
+                    "bugs": [
+                        {
+                            "id": 123,
+                            "flags": [
+                                {
+                                    "id": 6228688,
+                                    "type_id": 16,
+                                    "name": "needinfo",
+                                    "status": "?",
+                                    "setter": "user@example.com",
+                                    "requestee": "dev@example.com",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            )
+        )
+        flags = await bz_client.bug_flags(123)
+
+        assert route.called
+        # flags must be requested explicitly, else this instance omits them
+        assert route.calls.last.request.url.params.get("include_fields") == "id,flags"
+        assert len(flags) == 1
+        assert flags[0]["name"] == "needinfo"
+        assert flags[0]["id"] == 6228688
+
+
+@pytest.mark.asyncio
+async def test_bug_flags_empty(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.get("/rest/bug/123").mock(
+            return_value=Response(200, json={"bugs": [{"id": 123}]})
+        )
+        flags = await bz_client.bug_flags(123)
+        assert flags == []
+
+
+@pytest.mark.asyncio
 async def test_update_bug_single_field(bz_client):
     """Test updating a single field"""
     async with respx.mock(base_url=MOCK_URL) as respx_mock:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -312,3 +312,86 @@ async def test_list_attachments_tool_passthrough():
 
     assert [a["id"] for a in result] == [1, 2]
     bz.list_attachments.assert_awaited_once_with(123)
+
+
+@pytest.mark.asyncio
+async def test_get_bug_flags_passthrough():
+    bz = AsyncMock()
+    bz.bug_flags = AsyncMock(
+        return_value=[{"id": 6228688, "name": "needinfo", "status": "?"}]
+    )
+    result = await server.get_bug_flags(bug_id=123, bz=bz)
+    bz.bug_flags.assert_awaited_once_with(123)
+    assert result[0]["id"] == 6228688
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_set_by_name():
+    bz = AsyncMock()
+    bz.update_bug = AsyncMock(return_value={"bugs": [{"id": 123}]})
+    await server.update_bug_flag(
+        bug_id=123, status="?", name="needinfo", requestee="dev@example.com", bz=bz
+    )
+    bz.update_bug.assert_awaited_once_with(
+        123,
+        {
+            "flags": [
+                {"status": "?", "name": "needinfo", "requestee": "dev@example.com"}
+            ]
+        },
+        "",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_clear_by_id():
+    bz = AsyncMock()
+    bz.update_bug = AsyncMock(return_value={"bugs": [{"id": 123}]})
+    await server.update_bug_flag(bug_id=123, status="X", flag_id=6228688, bz=bz)
+    bz.update_bug.assert_awaited_once_with(
+        123, {"flags": [{"status": "X", "id": 6228688}]}, ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_clear_by_name():
+    bz = AsyncMock()
+    bz.update_bug = AsyncMock(return_value={"bugs": [{"id": 123}]})
+    await server.update_bug_flag(
+        bug_id=123, status="X", name="needinfo", requestee="dev@example.com", bz=bz
+    )
+    bz.update_bug.assert_awaited_once_with(
+        123,
+        {
+            "flags": [
+                {"status": "X", "name": "needinfo", "requestee": "dev@example.com"}
+            ]
+        },
+        "",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_requires_name_or_id():
+    bz = AsyncMock()
+    with pytest.raises(ToolError, match="Provide 'name'"):
+        await server.update_bug_flag(bug_id=123, status="?", bz=bz)
+    bz.update_bug.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_rejects_both_name_and_id():
+    bz = AsyncMock()
+    with pytest.raises(ToolError, match="not both"):
+        await server.update_bug_flag(
+            bug_id=123, status="X", name="needinfo", flag_id=42, bz=bz
+        )
+    bz.update_bug.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_flag_needinfo_requires_requestee():
+    bz = AsyncMock()
+    with pytest.raises(ToolError, match="requires a 'requestee'"):
+        await server.update_bug_flag(bug_id=123, status="?", name="needinfo", bz=bz)
+    bz.update_bug.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds support for Bugzilla **flags** — `needinfo`, `blocker`, tracker
approvals, and any other flag type an instance defines. The server could
previously neither view nor modify flags; this PR covers the full
lifecycle (read / set / grant / deny / clear).

The motivating case is `needinfo`, but the tools are generic over flag
name and work against any Bugzilla instance's flag types.

## What's added

- **`get_bug_flags(bug_id)`** — lists a bug's current flags with their
  instance `id`, `name`, `status`, `setter`, and `requestee`.
- **`update_bug_flag(bug_id, status, ...)`** — sets, grants, denies, or
  clears a flag, mirroring the REST API's two modes:
  - *Set a new flag* — pass `name` (and `requestee` for requestable flags
    like `needinfo`).
  - *Change/clear an existing flag* — pass `flag_id` (the instance id from
    `get_bug_flags`); `status="X"` clears it.
- **`Bugzilla.bug_flags()`** — client helper backing the read tool,
  following the existing `bug_info` request/error-handling pattern.

## Design notes

- **Flags are fetched explicitly** via `include_fields=id,flags`. Some
  instances (Red Hat Bugzilla among them) omit the `flags` array from the
  default bug view, so a plain bug fetch isn't sufficient — hence a
  dedicated read path rather than reusing `bug_info`.
- **Instance-id disambiguation.** A single flag type can exist several
  times on one bug (one `needinfo` per requestee), so changing or clearing
  a *specific* one needs its instance id. `get_bug_flags` surfaces it;
  `update_bug_flag`'s `flag_id` mode consumes it. Clearing by
  `name`+`requestee` also works for the common single-instance case.
- **Input guards** reject ambiguous calls up front — neither `name` nor
  `flag_id`, both together, or a `needinfo?` with no `requestee` — raising
  `ToolError` before any write.

## Testing

- Unit tests for the client method (`respx`) and every tool path:
  set-by-name, clear-by-id, clear-by-name, and the three guards (each
  asserting no write occurs).
- Verified end to end against a live Bugzilla instance: empty baseline →
  set `needinfo?` → read back the instance id → clear by id → confirm
  empty.

## Checklist

- [x] Tools in `server.py`, HTTP confined to `mcp_utils.py`
- [x] `ToolError` raised on API errors
- [x] Tests added (`test_mcp_utils.py`, `test_server.py`)
- [x] `CHANGELOG.md` updated