### PR TITLE
feat(info): add native field selection to bug_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `update_bug_flag` tool — set, grant, deny, or clear a bug flag (e.g. `needinfo`, `blocker`), by name+requestee or by flag instance id.
 - `bug_comments` gained SQL-like output controls to avoid flooding the context on large threads: `include_fields` (per-comment field projection, lean default), `exclude_creators` (drop comments by creator substring, e.g. bot noise), and `limit` (most recent N). Note: the `include_fields` default now returns a lean field set; pass `include_fields=None` for the full objects.
 - `bug_history` gained SQL-like output controls to cut low-signal churn (bot edits, cc/flag/summary changes): `changed_fields` (keep only changes to the named fields, dropping events left with no match), `exclude_authors` (drop events by author substring), and `limit` (most recent N). `exclude_authors` and `limit` are client-side conveniences with no server-side Bugzilla equivalent; `new_since` remains a native Bugzilla parameter.
+- `bug_info` gained native Bugzilla field selection: `include_fields` and `exclude_fields` (comma-separated), forwarded unchanged to the `Bug.get` API. Lets bulk and large fetches keep only the fields needed (e.g. `include_fields="id,status,resolution,summary"`). Both are native Bugzilla parameters; default behaviour (all fields) is unchanged.
 
 ## [v0.18.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ The server provides the following tools for interacting with Bugzilla:
 
 #### Bug Information
 
-- **`bug_info(bug_ids: set[int])`**: Retrieves comprehensive details for specified Bugzilla bug IDs.
+- **`bug_info(bug_ids: set[int], include_fields: Optional[str] = None, exclude_fields: Optional[str] = None)`**: Retrieves comprehensive details for specified Bugzilla bug IDs. By default every field is returned; use Bugzilla's native field selection to trim large or bulk fetches.
   - **Parameters**:
     - `bug_ids`: A set of bug IDs to fetch details for
-  - **Returns**: A dictionary containing the array `bugs` which lists all available information about the bugs (status, assignee, summary, description, extensions, etc.)
-  - **Example**: `bug_info({12345, 67890})` returns complete bug details for the specified IDs.
+    - `include_fields`: Comma-separated field names to return (Bugzilla's native `Bug.get` parameter; supports field groups and `_default`/`_all`/`_extra`). For the leanest response request only scalar fields, e.g. `"id,status,resolution,summary"`. Requesting a user field (`assigned_to`, `creator`, `cc`, `qa_contact`) also returns its verbose `*_detail` object. Defaults to all fields
+    - `exclude_fields`: Comma-separated field names to drop. To remove a user-object expansion, exclude both the base field and its `*_detail` together, e.g. `"cc,cc_detail"` — excluding the `*_detail` alone has no effect, as Bugzilla re-attaches it while the base field is present
+  - **Returns**: A dictionary containing the array `bugs` which lists the requested information about the bugs (status, assignee, summary, description, extensions, etc.)
+  - **Note on Bugzilla API parity**: both `include_fields` and `exclude_fields` are native Bugzilla `Bug.get` parameters, forwarded to the API unchanged; the underlying request is standard Bugzilla
+  - **Example**: `bug_info({12345, 67890}, include_fields="id,status,resolution,summary")` fetches two bugs with just the essential scalar fields
 
 - **`bug_history(id: int, new_since: Optional[datetime] = None, changed_fields: Optional[str] = None, exclude_authors: Optional[str] = None, limit: Optional[int] = None)`**: Fetches the change history of a given bug ID, with SQL-like controls to keep only the change events that matter for triage.
   - **Parameters**:

--- a/src/mcp_bugzilla/lib_bugzilla.py
+++ b/src/mcp_bugzilla/lib_bugzilla.py
@@ -126,7 +126,12 @@ class Bugzilla:
             mcp_log.error(f"[BZ-RES] Network Error: {e}")
             raise
 
-    async def bug_info(self, ids: set[int]) -> dict[str, Any]:
+    async def bug_info(
+        self,
+        ids: set[int],
+        include_fields: str | None = None,
+        exclude_fields: str | None = None,
+    ) -> dict[str, Any]:
         """Get information about a given bug or list of bugs"""
 
         if len(ids) == 1:
@@ -135,6 +140,11 @@ class Bugzilla:
         else:
             url = "/bug"
             params = {"id": ",".join(str(i) for i in ids)}
+
+        if include_fields:
+            params["include_fields"] = include_fields
+        if exclude_fields:
+            params["exclude_fields"] = exclude_fields
 
         mcp_log.info(f"[BZ-REQ] GET {self.api_url}{url} params={params}")
 

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -102,16 +102,42 @@ _get_bz = Depends(get_bz)
 
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
-async def bug_info(bug_ids: set[int], bz: Bugzilla = _get_bz) -> dict[str, Any]:
-    """Returns the entire information for one or more bugzilla bug ids."""
+async def bug_info(
+    bug_ids: set[int],
+    include_fields: str | None = None,
+    exclude_fields: str | None = None,
+    bz: Bugzilla = _get_bz,
+) -> dict[str, Any]:
+    """Returns information for one or more bugzilla bug ids.
 
-    mcp_log.info(f"[LLM-REQ] bug_info(ids={bug_ids})")
+    By default every field is returned. For large or bulk fetches, use
+    Bugzilla's native field selection (both are forwarded to Bug.get):
+
+      include_fields  Comma-separated fields to return. Supports field groups
+                      and the special values _default, _all, _extra. For the
+                      leanest response request only scalar fields, e.g.
+                      "id,status,resolution,summary". Note: requesting a user
+                      field (assigned_to, creator, cc, qa_contact) also returns
+                      its verbose *_detail object.
+      exclude_fields  Comma-separated fields to drop. To remove a user-object
+                      expansion, exclude BOTH the base field and its *_detail
+                      together, e.g. "cc,cc_detail" -- excluding the *_detail
+                      alone has no effect, because Bugzilla re-attaches it while
+                      the base field is present.
+    """
+
+    mcp_log.info(
+        f"[LLM-REQ] bug_info(ids={bug_ids}, include_fields={include_fields}, "
+        f"exclude_fields={exclude_fields})"
+    )
 
     if not bug_ids:
         raise ToolError("No bug IDs provided")
 
     try:
-        result = await bz.bug_info(bug_ids)
+        result = await bz.bug_info(
+            bug_ids, include_fields=include_fields, exclude_fields=exclude_fields
+        )
         return result
 
     except Exception as e:  # noqa: BLE001

--- a/tests/test_lib_bugzilla.py
+++ b/tests/test_lib_bugzilla.py
@@ -777,3 +777,29 @@ async def test_bearer_client_sends_auth_header_not_param():
             assert "authorization" in dict(route.calls.last.request.headers)
     finally:
         await client.close()
+
+
+@pytest.mark.asyncio
+async def test_bug_info_forwards_field_selection(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.get("/rest/bug/123").mock(
+            return_value=Response(200, json={"bugs": [{"id": 123}], "faults": []})
+        )
+        await bz_client.bug_info(
+            {123}, include_fields="id,status", exclude_fields="cc_detail"
+        )
+        q = route.calls.last.request.url.params
+        assert q.get("include_fields") == "id,status"
+        assert q.get("exclude_fields") == "cc_detail"
+
+
+@pytest.mark.asyncio
+async def test_bug_info_omits_field_selection_when_none(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.get("/rest/bug/123").mock(
+            return_value=Response(200, json={"bugs": [{"id": 123}], "faults": []})
+        )
+        await bz_client.bug_info({123})
+        q = route.calls.last.request.url.params
+        assert "include_fields" not in q
+        assert "exclude_fields" not in q

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -499,3 +499,26 @@ async def test_bug_history_limit_keeps_most_recent():
     bz.bug_history = AsyncMock(return_value=[dict(h) for h in _HIST])
     out = await server.bug_history(id=42, limit=1, bz=bz)
     assert len(out) == 1 and out[0]["when"] == "2026-03-01T00:00:00Z"  # newest
+
+
+@pytest.mark.asyncio
+async def test_bug_info_passes_field_selection_through():
+    bz = AsyncMock()
+    bz.bug_info = AsyncMock(return_value={"bugs": [{"id": 1}], "faults": []})
+    await server.bug_info(
+        bug_ids={1},
+        include_fields="id,status,summary",
+        exclude_fields="cc_detail",
+        bz=bz,
+    )
+    bz.bug_info.assert_awaited_once_with(
+        {1}, include_fields="id,status,summary", exclude_fields="cc_detail"
+    )
+
+
+@pytest.mark.asyncio
+async def test_bug_info_defaults_to_full_response():
+    bz = AsyncMock()
+    bz.bug_info = AsyncMock(return_value={"bugs": [{"id": 1}], "faults": []})
+    await server.bug_info(bug_ids={1}, bz=bz)
+    bz.bug_info.assert_awaited_once_with({1}, include_fields=None, exclude_fields=None)


### PR DESCRIPTION
## Summary

`bug_info` returns every field of every requested bug — wasteful for bulk fetches (it accepts a set of ids) and large bugs. This forwards Bugzilla's own field-selection parameters:

- **`include_fields`** — comma-separated fields to return (native `Bug.get`; supports field groups and `_default`/`_all`/`_extra`).
- **`exclude_fields`** — comma-separated fields to drop.

## Verified live

Tested against a real bug before opening:

- `include_fields="id,status,resolution,summary,component,last_change_time"` → exactly those fields (plus Bugzilla's always-on `data_category`); ~46 fields down to 6.
- `include_fields="id,status,summary,assigned_to"` → the requested fields **plus `assigned_to_detail`** — Bugzilla auto-attaches the `*_detail` object to any requested user field.
- `exclude_fields="cc,cc_detail,update_token,keywords,groups"` → all five dropped, confirming exclusion works and that a `*_detail` is removed only when its base field is excluded alongside it.

## Behaviour note

The `*_detail` user-object expansions are bound by Bugzilla to their base user-field: excluding a `*_detail` alone has no effect (the server re-adds it), so to drop the expansion exclude the base field too (e.g. `cc,cc_detail`). Keeping the base email while dropping only its detail object is not possible via the API.

## Note on Bugzilla API parity

Both parameters are native Bugzilla `Bug.get` parameters, forwarded unchanged — server-side field selection, reducing wire as well as context cost, with no divergence from the API. The default (all fields) is unchanged, so the change is strictly additive.

## Testing

- Client tests (`respx`, `test_lib_bugzilla.py`): parameters forwarded when set, omitted when `None`.
- Tool tests (`AsyncMock`, `test_server.py`): passthrough and default.
- Live-verified (results above).