### PR TITLE
feat(attachments): add filtering to list_attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `bug_comments` gained SQL-like output controls to avoid flooding the context on large threads: `include_fields` (per-comment field projection, lean default), `exclude_creators` (drop comments by creator substring, e.g. bot noise), and `limit` (most recent N). Note: the `include_fields` default now returns a lean field set; pass `include_fields=None` for the full objects.
 - `bug_history` gained SQL-like output controls to cut low-signal churn (bot edits, cc/flag/summary changes): `changed_fields` (keep only changes to the named fields, dropping events left with no match), `exclude_authors` (drop events by author substring), and `limit` (most recent N). `exclude_authors` and `limit` are client-side conveniences with no server-side Bugzilla equivalent; `new_since` remains a native Bugzilla parameter.
 - `bug_info` gained native Bugzilla field selection: `include_fields` and `exclude_fields` (comma-separated), forwarded unchanged to the `Bug.get` API. Lets bulk and large fetches keep only the fields needed (e.g. `include_fields="id,status,resolution,summary"`). Both are native Bugzilla parameters; default behaviour (all fields) is unchanged.
+- `list_attachments` gained filters to cut noise on bugs with many attachments: `exclude_obsolete` (drop obsolete attachments), `patches_only` (keep only patches), and `limit` (most recent N). All are client-side; there is no native Bugzilla equivalent.
 
 ## [v0.18.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,15 @@ The server provides the following tools for interacting with Bugzilla:
 
 #### Attachments
 
-- **`list_attachments(bug_id: int)`**: Lists a bug's attachments as metadata only (the base64 file contents are excluded to keep responses small).
+- **`list_attachments(bug_id: int, exclude_obsolete: bool = False, patches_only: bool = False, limit: Optional[int] = None)`**: Lists a bug's attachments as metadata only (the base64 file contents are excluded to keep responses small), with filters to cut the noise on bugs that accumulate many attachments.
   - **Parameters**:
     - `bug_id`: The bug whose attachments to list
+    - `exclude_obsolete`: Drop attachments flagged obsolete (`is_obsolete`). Note: some bots (e.g. release-monitoring) never set this flag, so it only helps where obsolete is actually used
+    - `patches_only`: Keep only attachments flagged as patches (`is_patch`)
+    - `limit`: Return only the most recent N attachments (chronological order preserved)
   - **Returns**: A list of attachment metadata objects (`id`, `file_name`, `summary`, `content_type`, `size`, `is_private`, `is_obsolete`, `is_patch`, `creation_time`, ...). Use an `id` with `download_attachment` to fetch the file.
-  - **Example**: `list_attachments(989633)`
+  - **Note on Bugzilla API parity**: `exclude_obsolete`, `patches_only`, and `limit` have no server-side Bugzilla equivalent — this server applies them client-side, as post-processing over the standard attachment metadata; the underlying Bugzilla request is unmodified
+  - **Example**: `list_attachments(2381747, patches_only=True, limit=3)` returns the 3 most recent patch attachments
 
 - **`download_attachment(attachment_id: int, output_dir: Optional[str] = None, delivery: "auto" | "inline" | "save" = "auto", include_private: bool = False)`**: Downloads a single attachment by id. The `delivery` argument lets the caller choose how the content is returned.
   - **Parameters**:

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -791,27 +791,50 @@ async def add_attachment(
         raise ToolError(f"Failed to add attachment\n{e}")
 
 
-@mcp.tool(
-    annotations={"readOnlyHint": True, "openWorldHint": True},
-    tags={"read"},
-)
-async def list_attachments(bug_id: int, bz: Bugzilla = _get_bz) -> list[dict[str, Any]]:
-    """List a bug's attachments (metadata only, without the file contents).
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
+async def list_attachments(
+    bug_id: int,
+    exclude_obsolete: bool = False,
+    patches_only: bool = False,
+    limit: int | None = None,
+    bz: Bugzilla = _get_bz,
+) -> list[dict[str, Any]]:
+    """List a bug's attachments (metadata only; base64 contents excluded).
 
-    Use this to discover attachment ids, then pass an id to ``download_attachment``
-    to fetch the actual file. The base64 ``data`` field is intentionally omitted
-    here to keep responses small.
+    Long-lived bugs accumulate many attachments (e.g. a patch re-attached on
+    every version bump), so these filters keep only the relevant ones:
 
-    Args:
-        bug_id: The bug whose attachments to list.
+      exclude_obsolete  Drop attachments flagged obsolete (is_obsolete). Note:
+                        some bots (e.g. release-monitoring) never set this
+                        flag, so it only helps where obsolete is actually used.
+      patches_only      Keep only attachments flagged as patches (is_patch).
+      limit             Return only the most recent N attachments
+                        (chronological order preserved).
 
-    Returns:
-        A list of attachment metadata objects (id, file_name, summary,
-        content_type, size, is_private, is_obsolete, is_patch, creation_time, ...).
+    Use an attachment's id with download_attachment to fetch the file.
     """
-    mcp_log.info(f"[LLM-REQ] list_attachments(bug_id={bug_id})")
+    mcp_log.info(
+        f"[LLM-REQ] list_attachments(bug_id={bug_id}, "
+        f"exclude_obsolete={exclude_obsolete}, patches_only={patches_only}, "
+        f"limit={limit})"
+    )
     try:
-        return await bz.list_attachments(bug_id)
+        attachments = await bz.list_attachments(bug_id)
+
+        # WHERE NOT is_obsolete
+        if exclude_obsolete:
+            attachments = [a for a in attachments if not a.get("is_obsolete")]
+
+        # WHERE is_patch
+        if patches_only:
+            attachments = [a for a in attachments if a.get("is_patch")]
+
+        # LIMIT to the most recent N (chronological order preserved)
+        if limit and limit > 0:
+            attachments = attachments[-limit:]
+
+        mcp_log.info(f"[LLM-RES] Returning {len(attachments)} attachments")
+        return attachments
     except Exception as e:  # noqa: BLE001
         raise ToolError(f"Failed to list attachments\nReason: {e}")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -522,3 +522,70 @@ async def test_bug_info_defaults_to_full_response():
     bz.bug_info = AsyncMock(return_value={"bugs": [{"id": 1}], "faults": []})
     await server.bug_info(bug_ids={1}, bz=bz)
     bz.bug_info.assert_awaited_once_with({1}, include_fields=None, exclude_fields=None)
+
+
+_ATT = [
+    {
+        "id": 1,
+        "is_obsolete": 1,
+        "is_patch": 1,
+        "file_name": "old.patch",
+        "creation_time": "2025-01-01T00:00:00Z",
+    },
+    {
+        "id": 2,
+        "is_obsolete": 0,
+        "is_patch": 1,
+        "file_name": "new.patch",
+        "creation_time": "2025-02-01T00:00:00Z",
+    },
+    {
+        "id": 3,
+        "is_obsolete": 0,
+        "is_patch": 0,
+        "file_name": "build.log",
+        "creation_time": "2025-03-01T00:00:00Z",
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_default_returns_all():
+    bz = AsyncMock()
+    bz.list_attachments = AsyncMock(return_value=[dict(a) for a in _ATT])
+    out = await server.list_attachments(bug_id=42, bz=bz)
+    assert [a["id"] for a in out] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_exclude_obsolete():
+    bz = AsyncMock()
+    bz.list_attachments = AsyncMock(return_value=[dict(a) for a in _ATT])
+    out = await server.list_attachments(bug_id=42, exclude_obsolete=True, bz=bz)
+    assert [a["id"] for a in out] == [2, 3]  # obsolete id 1 dropped
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_patches_only():
+    bz = AsyncMock()
+    bz.list_attachments = AsyncMock(return_value=[dict(a) for a in _ATT])
+    out = await server.list_attachments(bug_id=42, patches_only=True, bz=bz)
+    assert [a["id"] for a in out] == [1, 2]  # non-patch log id 3 dropped
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_limit_keeps_most_recent():
+    bz = AsyncMock()
+    bz.list_attachments = AsyncMock(return_value=[dict(a) for a in _ATT])
+    out = await server.list_attachments(bug_id=42, limit=1, bz=bz)
+    assert [a["id"] for a in out] == [3]  # newest kept, chronological order
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_filters_compose():
+    bz = AsyncMock()
+    bz.list_attachments = AsyncMock(return_value=[dict(a) for a in _ATT])
+    out = await server.list_attachments(
+        bug_id=42, exclude_obsolete=True, patches_only=True, bz=bz
+    )
+    assert [a["id"] for a in out] == [2]  # only the non-obsolete patch


### PR DESCRIPTION
## Summary

Long-lived bugs accumulate many attachments — a release-monitoring bug had 30 patches, one re-attached on every version bump. `list_attachments` currently returns them all. This adds filters to keep only the relevant ones:

- **`exclude_obsolete`** — drop attachments flagged obsolete (`is_obsolete`).
- **`patches_only`** — keep only attachments flagged as patches (`is_patch`).
- **`limit`** — return only the most recent N (chronological order preserved).

All three are client-side post-processing over the standard attachment metadata; there is no server-side Bugzilla equivalent.

## Verified live

- `limit=3` on a 30-patch release-monitoring bug → the 3 most recent patches, chronological order preserved.
- `patches_only=True` → **keeps** patches on the patch bug, and **drops** non-patches on a build-failure bug whose attachments are all logs (returned `[]`).
- `exclude_obsolete=True` → on a bug with a superseded patch (one obsolete + one current), returned **only the current one (2 → 1)**; and on a bug where nothing is flagged obsolete, correctly returned all attachments unchanged (a no-op — the release-monitoring bot never sets the flag).

## Note on Bugzilla API parity

`exclude_obsolete`, `patches_only`, and `limit` have no server-side Bugzilla equivalent — this server applies them client-side, as post-processing over the standard attachment metadata; the underlying Bugzilla request is unmodified.

## Testing

- Tool tests (`AsyncMock`, `test_server.py`): default passthrough, each filter alone, `limit` recency/ordering, and the `exclude_obsolete` + `patches_only` composition case. `is_*` fixtures use integers `0`/`1` to match Bugzilla and guard against a `== True` regression.

## Checklist

- [x] Tool change in `server.py` (client method unchanged — it already excludes `data`)
- [x] `ToolError` preserved on API errors
- [x] Tests added (`test_server.py`)
- [x] `CHANGELOG.md` and `README.md` updated