### PR TITLE
fix(attachments): coerce Bugzilla int flags to bool in download result

### DIFF
--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -839,6 +839,11 @@ async def list_attachments(
         raise ToolError(f"Failed to list attachments\nReason: {e}")
 
 
+def _as_optional_bool(value: Any) -> bool | None:
+    """Bugzilla returns flag fields as 0/1 ints; coerce to bool, preserve None."""
+    return None if value is None else bool(value)
+
+
 class _AttachmentMeta(TypedDict):
     """Metadata returned with every download_attachment result."""
 
@@ -932,8 +937,8 @@ async def download_attachment(
             "file_name": att.get("file_name"),
             "content_type": content_type,
             "size": len(raw),
-            "is_private": att.get("is_private"),
-            "is_obsolete": att.get("is_obsolete"),
+            "is_private": _as_optional_bool(att.get("is_private")),
+            "is_obsolete": _as_optional_bool(att.get("is_obsolete")),
         }
 
         def _save() -> SavedAttachment:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -280,6 +280,27 @@ async def test_download_attachment_private_allowed_with_flag(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_download_attachment_int_flags_coerced_to_bool(tmp_path):
+    # Bugzilla's REST API returns is_private/is_obsolete as 0/1 ints; they must
+    # surface as real bools or FastMCP rejects the output schema.
+    server.download_dir = str(tmp_path)
+    att = {
+        "id": 50,
+        "file_name": "log.txt",
+        "content_type": "text/plain",
+        "size": 5,
+        "is_private": 0,
+        "is_obsolete": 1,
+        "data": base64.b64encode(b"hello").decode(),
+    }
+
+    result = await server.download_attachment(attachment_id=50, bz=_fake_bz(att))
+
+    assert result["is_private"] is False
+    assert result["is_obsolete"] is True
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(os.name != "posix", reason="POSIX file modes only")
 async def test_download_attachment_default_dir_is_owner_only(tmp_path):
     import stat


### PR DESCRIPTION
Bugzilla's REST API returns is_private/is_obsolete as 0/1 integers, but the download_attachment output schema types them as Optional[bool]. FastMCP validated the structured output against the schema and rejected the ints, failing with a -32602 "does not match the tool's output schema" error (which also surfaced a misleading "required property 'data_base64'" because the whole DownloadResult union then failed to match any branch).

Coerce the flags to bool (preserving None) when building the result metadata.