### PR TITLE
Component defaults and resetting to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+- `update_bug_fields` gains `reset_qa_contact` and `reset_assigned_to` flags. These map to Bugzilla's native `Bug.update` booleans, so the default is resolved server-side rather than written back by the client.
+
 ## [v0.19.0] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 - `update_bug_fields` gains `reset_qa_contact` and `reset_assigned_to` flags. These map to Bugzilla's native `Bug.update` booleans, so the default is resolved server-side rather than written back by the client.
+- New read-only `get_component_defaults` tool returns a component's default assignee and QA contact. Bugzilla has no component endpoint, so the defaults are read from the parent product (new `Bugzilla.get_product` helper). Takes an explicit `product`/`component`, or a `bug_id` to resolve them from a bug.
 
 ## [v0.19.0] - 2026-08-11
 

--- a/README.md
+++ b/README.md
@@ -113,16 +113,20 @@ The server provides the following tools for interacting with Bugzilla:
   + **Returns**: A dictionary containing the updated bug fields
   + **Example**: `assign_bug(12345, "developer@example.com", comment="You're the expert on this component")`
 
-* **`update_bug_fields(bug_id: int, priority: str = None, severity: str = None, resolution: str = None, comment: str = "")`**: Updates various bug fields.
+* **`update_bug_fields(bug_id: int, priority: str = None, severity: str = None, resolution: str = None, custom_fields: dict = None, reset_qa_contact: bool = False, reset_assigned_to: bool = False, comment: str = "")`**: Updates various bug fields.
 
   + **Parameters**:
     - `bug_id`: The bug ID to update
     - `priority`: Priority level (e.g., `urgent`, `high`, `medium`, `low`, `unspecified`)
     - `severity`: Severity level (e.g., `urgent`, `high`, `medium`, `low`, `unspecified`)
     - `resolution`: Resolution (only for closed bugs)
+    - `custom_fields`: Dict of custom fields, e.g. `{"cf_fixed_in": "1.2.3"}`
+    - `reset_qa_contact`: If `True`, reset the QA contact to the component's default
+    - `reset_assigned_to`: If `True`, reset the assignee to the component's default
     - `comment`: Optional comment explaining the changes
   + **Returns**: A dictionary containing the updated bug fields
   + **Example**: `update_bug_fields(12345, priority="high", severity="urgent", comment="Escalating due to customer impact")`
+  + **Example**: `update_bug_fields(12345, reset_qa_contact=True)` resets the QA contact to the component default
 
 * **`add_cc_to_bug(bug_id: int, cc_email: str)`**: Adds an email address to the CC list of a bug.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ The server provides the following tools for interacting with Bugzilla:
   - **Note on Bugzilla API parity**: `new_since` and `include_fields` mirror Bugzilla's own API parameters of the same names (`include_fields` is applied client-side here). `exclude_creators` and `limit` have no server-side Bugzilla equivalent — this server applies them client-side, as post-processing over the standard `Bug.comments` response; the underlying Bugzilla request is unmodified.
   - **Example**: `bug_comments(12345, exclude_creators="upstream-release-monitoring", limit=5)` returns the 5 most recent comments that aren't from the release-monitoring bot
 
+- **`get_component_defaults(component: str = None, product: str = None, bug_id: int = None)`**: Looks up a component's default assignee and QA contact, read from the parent product since Bugzilla has no component endpoint.
+  - **Parameters**:
+    - `component`: Component name (resolved from `bug_id` if omitted)
+    - `product`: Product the component belongs to (resolved from `bug_id` if omitted)
+    - `bug_id`: Resolve product/component from this bug instead of passing them
+  - **Returns**: A dictionary with `product`, `component`, `default_assignee`, `default_qa_contact`, `is_active`
+  - **Example**: `get_component_defaults(bug_id=12345)` returns the defaults for that bug's component. To reset a bug *to* these defaults, use `update_bug_fields(..., reset_qa_contact=True)`.
+
 
 - **`add_comment(bug_id: int, comment: str, is_private: bool = False)`**: Adds a new comment to a specified bug.
   - **Parameters**:

--- a/src/mcp_bugzilla/lib_bugzilla.py
+++ b/src/mcp_bugzilla/lib_bugzilla.py
@@ -197,6 +197,46 @@ class Bugzilla:
         mcp_log.debug(f"[BZ-RES] {envelope}")
         return envelope
 
+    async def get_product(
+        self, name: str, include_fields: str | None = None
+    ) -> dict[str, Any]:
+        """Fetch a product by name, with its components and their defaults.
+
+        Bugzilla has no component endpoint: component defaults (assignee, QA
+        contact) are only exposed nested under the parent product. The full
+        payload is large, so pass ``include_fields`` (dotted paths work, e.g.
+        ``components.default_assigned_to``) to keep only what is needed.
+        """
+        params = {"names": name}
+        if include_fields:
+            params["include_fields"] = include_fields
+        mcp_log.info(f"[BZ-REQ] GET {self.api_url}/product params={params}")
+
+        try:
+            r = await self.client.get("/product", params=params)
+            r.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            bz_error = _bugzilla_error_body(e.response)
+            if bz_error is not None:
+                mcp_log.error(
+                    f"[BZ-RES] Failed: {e.response.status_code} "
+                    f"code={bz_error.get('code')} {bz_error['message']}"
+                )
+                raise BugzillaAPIError(e.response.status_code, bz_error) from e
+            mcp_log.error(
+                f"[BZ-RES] Failed: {e.response.status_code} {e.response.text}"
+            )
+            raise
+        except httpx.RequestError as e:
+            mcp_log.error(f"[BZ-RES] Network Error: {e}")
+            raise
+
+        envelope = _json_or_raise(r)
+        products = envelope.get("products", [])
+        mcp_log.info(f"[BZ-RES] Retrieved {len(products)} products")
+        mcp_log.debug(f"[BZ-RES] {envelope}")
+        return envelope
+
     async def bug_flags(self, bug_id: int) -> list[dict[str, Any]]:
         """Return the flags currently set on a bug, with their instance ids.
 

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -144,6 +144,107 @@ async def bug_info(
         raise ToolError(f"Failed to fetch bug info\nReason: {e}")
 
 
+class ComponentDefaults(TypedDict):
+    """A component's default assignee and QA contact.
+
+    ``default_assignee`` / ``default_qa_contact`` are ``None`` both when the
+    component has none set and when the API key cannot see them. Bugzilla
+    reports an unset contact as an empty string; that is normalised to ``None``
+    so the two cases read alike.
+    """
+
+    product: str
+    component: str
+    default_assignee: str | None
+    default_qa_contact: str | None
+    is_active: bool | None
+
+
+@mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
+async def get_component_defaults(
+    component: str | None = None,
+    product: str | None = None,
+    bug_id: int | None = None,
+    bz: Bugzilla = _get_bz,
+) -> ComponentDefaults:
+    """Look up a component's default assignee and QA contact.
+
+    Bugzilla has no component endpoint, so the defaults come from the parent
+    product. Pass ``product`` and ``component``, or a ``bug_id`` to resolve them
+    from that bug; explicit values win. To reset a bug *to* these defaults, use
+    ``update_bug_fields`` with ``reset_qa_contact`` / ``reset_assigned_to``.
+
+    Args:
+        component: Component name (resolved from bug_id if omitted)
+        product: Product the component belongs to (resolved from bug_id if omitted)
+        bug_id: Resolve product/component from this bug instead of passing them
+    """
+    mcp_log.info(
+        f"[LLM-REQ] get_component_defaults(component={component!r}, "
+        f"product={product!r}, bug_id={bug_id})"
+    )
+
+    try:
+        resolved_from_bug = False
+        if bug_id is not None and (not product or not component):
+            envelope = await bz.bug_info({bug_id}, include_fields="product,component")
+            bugs = envelope.get("bugs", [])
+            if not bugs:
+                raise ToolError(f"Bug {bug_id} not found")
+            product = product or bugs[0].get("product")
+            component = component or bugs[0].get("component")
+            resolved_from_bug = True
+
+        if not product:
+            raise ToolError(
+                f"Bug {bug_id} returned no product field"
+                if resolved_from_bug
+                else "Either `product` or `bug_id` must be supplied"
+            )
+        if not component:
+            raise ToolError(
+                f"Bug {bug_id} returned no component field; pass `component` explicitly"
+                if resolved_from_bug
+                else "Either `component` or `bug_id` must be supplied"
+            )
+
+        # The full product payload is ~10x larger and carries flag_types,
+        # milestones and versions this tool never reads.
+        envelope = await bz.get_product(
+            product,
+            include_fields=(
+                "name,components.name,components.default_assigned_to,"
+                "components.default_qa_contact,components.is_active"
+            ),
+        )
+        products = envelope.get("products", [])
+        if not products:
+            raise ToolError(f"Product {product!r} not found")
+
+        components = products[0].get("components", [])
+        for comp in components:
+            if comp.get("name") == component:
+                return ComponentDefaults(
+                    product=product,
+                    component=component,
+                    # Bugzilla's key is default_assigned_to, not default_assignee,
+                    # and an unset contact comes back as "" rather than null.
+                    default_assignee=comp.get("default_assigned_to") or None,
+                    default_qa_contact=comp.get("default_qa_contact") or None,
+                    is_active=comp.get("is_active"),
+                )
+
+        available = ", ".join(c.get("name", "?") for c in components)
+        raise ToolError(
+            f"Component {component!r} not found in product {product!r}. "
+            f"Available components: {available}"
+        )
+    except ToolError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        raise ToolError(f"Failed to fetch component defaults\n{e}")
+
+
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bug_history(
     id: int,

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -520,6 +520,8 @@ async def update_bug_fields(
     severity: str | None = None,
     resolution: str | None = None,
     custom_fields: dict[str, Any] | None = None,
+    reset_qa_contact: bool = False,
+    reset_assigned_to: bool = False,
     comment: str = "",
     bz: Bugzilla = _get_bz,
 ) -> dict[str, Any]:
@@ -531,10 +533,13 @@ async def update_bug_fields(
         severity: Severity (e.g., urgent, high, medium, low, unspecified)
         resolution: Resolution (e.g., FIXED, WONTFIX, NOTABUG, DUPLICATE) - only for closed bugs
         custom_fields: Dict of custom fields e.g. {"cf_fixed_in": "1.2.3"}
+        reset_qa_contact: Reset the QA contact to the component's default
+        reset_assigned_to: Reset the assignee to the component's default
         comment: Optional comment explaining the changes
     """
     mcp_log.info(
-        f"[LLM-REQ] update_bug_fields(bug_id={bug_id}, priority={priority}, severity={severity}, resolution={resolution})"
+        f"[LLM-REQ] update_bug_fields(bug_id={bug_id}, priority={priority}, severity={severity}, "
+        f"resolution={resolution}, reset_qa_contact={reset_qa_contact}, reset_assigned_to={reset_assigned_to})"
     )
 
     updates = {}
@@ -546,6 +551,10 @@ async def update_bug_fields(
         updates["resolution"] = resolution
     if custom_fields:
         updates.update(custom_fields)
+    if reset_qa_contact:
+        updates["reset_qa_contact"] = True
+    if reset_assigned_to:
+        updates["reset_assigned_to"] = True
 
     if not updates:
         raise ToolError("At least one field must be specified")

--- a/tests/test_lib_bugzilla.py
+++ b/tests/test_lib_bugzilla.py
@@ -5,7 +5,11 @@ import pytest_asyncio
 import respx
 from httpx import Response
 
-from mcp_bugzilla.lib_bugzilla import Bugzilla, BugzillaResponseError
+from mcp_bugzilla.lib_bugzilla import (
+    Bugzilla,
+    BugzillaAPIError,
+    BugzillaResponseError,
+)
 from mcp_bugzilla.mcp_utils import is_textual, safe_filename
 
 MOCK_URL = "https://bugzilla.example.com"
@@ -826,3 +830,56 @@ async def test_bug_info_omits_field_selection_when_none(bz_client):
         q = route.calls.last.request.url.params
         assert "include_fields" not in q
         assert "exclude_fields" not in q
+
+
+@pytest.mark.asyncio
+async def test_get_product_returns_envelope(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        route = respx_mock.get("/rest/product").mock(
+            return_value=Response(
+                200,
+                json={
+                    "products": [
+                        {
+                            "id": 15,
+                            "name": "ProdX",
+                            "components": [
+                                {
+                                    "id": 1421,
+                                    "name": "Release Notes",
+                                    "default_assigned_to": "dev@example.com",
+                                    "default_qa_contact": "qa@example.com",
+                                    "is_active": True,
+                                }
+                            ],
+                        }
+                    ]
+                },
+            )
+        )
+
+        envelope = await bz_client.get_product(
+            "ProdX", include_fields="name,components.name"
+        )
+
+        assert envelope["products"][0]["components"][0]["name"] == "Release Notes"
+        params = route.calls.last.request.url.params
+        assert params["names"] == "ProdX"
+        assert params["include_fields"] == "name,components.name"
+
+
+@pytest.mark.asyncio
+async def test_get_product_error_body_surfaced(bz_client):
+    async with respx.mock(base_url=MOCK_URL) as respx_mock:
+        respx_mock.get("/rest/product").mock(
+            return_value=Response(
+                404,
+                json={"error": True, "code": 51, "message": "No product named 'Nope'."},
+            )
+        )
+
+        with pytest.raises(BugzillaAPIError) as exc:
+            await bz_client.get_product("Nope")
+
+        assert exc.value.code == 51
+        assert "No product named" in exc.value.message

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -610,3 +610,83 @@ async def test_list_attachments_filters_compose():
         bug_id=42, exclude_obsolete=True, patches_only=True, bz=bz
     )
     assert [a["id"] for a in out] == [2]  # only the non-obsolete patch
+
+
+def _update_bz():
+    """A stand-in Bugzilla client exposing only update_bug."""
+    bz = AsyncMock()
+    bz.update_bug = AsyncMock(return_value={"bugs": [{"id": 123}]})
+    return bz
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_no_reset_keys_by_default():
+    """A normal update must not ship reset_* keys when the flags are False."""
+    bz = _update_bz()
+
+    await server.update_bug_fields(bug_id=123, priority="high", bz=bz)
+
+    bz.update_bug.assert_awaited_once_with(123, {"priority": "high"}, "")
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_reset_qa_contact():
+    bz = _update_bz()
+
+    await server.update_bug_fields(bug_id=123, reset_qa_contact=True, bz=bz)
+
+    bz.update_bug.assert_awaited_once_with(123, {"reset_qa_contact": True}, "")
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_reset_assigned_to():
+    bz = _update_bz()
+
+    await server.update_bug_fields(bug_id=123, reset_assigned_to=True, bz=bz)
+
+    bz.update_bug.assert_awaited_once_with(123, {"reset_assigned_to": True}, "")
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_reset_both_with_other_fields():
+    bz = _update_bz()
+
+    await server.update_bug_fields(
+        bug_id=123,
+        priority="high",
+        reset_qa_contact=True,
+        reset_assigned_to=True,
+        comment="reset to defaults",
+        bz=bz,
+    )
+
+    bz.update_bug.assert_awaited_once_with(
+        123,
+        {
+            "priority": "high",
+            "reset_qa_contact": True,
+            "reset_assigned_to": True,
+        },
+        "reset to defaults",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_bare_reset_is_valid():
+    """A reset-only call must satisfy the 'at least one field' guard."""
+    bz = _update_bz()
+
+    # Must not raise "At least one field must be specified".
+    await server.update_bug_fields(bug_id=123, reset_qa_contact=True, bz=bz)
+
+    bz.update_bug.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_bug_fields_no_fields_raises():
+    bz = _update_bz()
+
+    with pytest.raises(ToolError, match="At least one field"):
+        await server.update_bug_fields(bug_id=123, bz=bz)
+
+    bz.update_bug.assert_not_awaited()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -676,7 +676,6 @@ async def test_update_bug_fields_bare_reset_is_valid():
     """A reset-only call must satisfy the 'at least one field' guard."""
     bz = _update_bz()
 
-    # Must not raise "At least one field must be specified".
     await server.update_bug_fields(bug_id=123, reset_qa_contact=True, bz=bz)
 
     bz.update_bug.assert_awaited_once()
@@ -690,3 +689,161 @@ async def test_update_bug_fields_no_fields_raises():
         await server.update_bug_fields(bug_id=123, bz=bz)
 
     bz.update_bug.assert_not_awaited()
+
+
+def _product_envelope():
+    # Bugzilla's key is default_assigned_to, not default_assignee.
+    return {
+        "products": [
+            {
+                "id": 15,
+                "name": "ProdX",
+                "components": [
+                    {
+                        "name": "Release Notes",
+                        "default_assigned_to": "dev@example.com",
+                        "default_qa_contact": "qa@example.com",
+                        "is_active": True,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _product_bz(envelope=None):
+    bz = AsyncMock()
+    bz.get_product = AsyncMock(
+        return_value=envelope if envelope is not None else _product_envelope()
+    )
+    return bz
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_explicit_product():
+    bz = _product_bz()
+
+    result = await server.get_component_defaults(
+        component="Release Notes", product="ProdX", bz=bz
+    )
+
+    assert result["default_qa_contact"] == "qa@example.com"
+    assert result["default_assignee"] == "dev@example.com"
+    assert result["is_active"] is True
+    bz.get_product.assert_awaited_once()
+    assert bz.get_product.await_args.args[0] == "ProdX"
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_resolves_from_bug_id():
+    bz = _product_bz()
+    bz.bug_info = AsyncMock(
+        return_value={"bugs": [{"product": "ProdX", "component": "Release Notes"}]}
+    )
+
+    result = await server.get_component_defaults(bug_id=42, bz=bz)
+
+    assert result["product"] == "ProdX"
+    assert result["component"] == "Release Notes"
+    assert result["default_assignee"] == "dev@example.com"
+    assert result["default_qa_contact"] == "qa@example.com"
+    bz.bug_info.assert_awaited_once_with({42}, include_fields="product,component")
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_explicit_product_wins_over_bug_id():
+    """An explicit product/component must skip the bug lookup entirely."""
+    bz = _product_bz()
+    bz.bug_info = AsyncMock()
+
+    result = await server.get_component_defaults(
+        component="Release Notes", product="ProdX", bug_id=42, bz=bz
+    )
+
+    assert result["default_assignee"] == "dev@example.com"
+    bz.bug_info.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_absent_defaults_are_none():
+    """A component missing the default keys yields None, not KeyError."""
+    bz = _product_bz({"products": [{"components": [{"name": "Release Notes"}]}]})
+
+    result = await server.get_component_defaults(
+        component="Release Notes", product="ProdX", bz=bz
+    )
+
+    assert result["default_assignee"] is None
+    assert result["default_qa_contact"] is None
+    assert result["is_active"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_empty_string_defaults_are_none():
+    """Bugzilla reports an unset contact as "", which must surface as None."""
+    bz = _product_bz(
+        {
+            "products": [
+                {
+                    "components": [
+                        {
+                            "name": "Release Notes",
+                            "default_assigned_to": "dev@example.com",
+                            "default_qa_contact": "",
+                            "is_active": False,
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    result = await server.get_component_defaults(
+        component="Release Notes", product="ProdX", bz=bz
+    )
+
+    assert result["default_qa_contact"] is None
+    assert result["default_assignee"] == "dev@example.com"
+    # False is a real value, not a missing one.
+    assert result["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_bug_not_found():
+    bz = _product_bz()
+    bz.bug_info = AsyncMock(return_value={"bugs": []})
+
+    with pytest.raises(ToolError, match="Bug 42 not found"):
+        await server.get_component_defaults(bug_id=42, bz=bz)
+
+    bz.get_product.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_product_not_found():
+    bz = _product_bz({"products": []})
+
+    with pytest.raises(ToolError, match="Product 'Nope' not found"):
+        await server.get_component_defaults(
+            component="Release Notes", product="Nope", bz=bz
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_component_not_found():
+    bz = _product_bz()
+
+    with pytest.raises(ToolError, match="not found in product"):
+        await server.get_component_defaults(
+            component="Nonexistent", product="ProdX", bz=bz
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_component_defaults_requires_product_or_bug_id():
+    bz = _product_bz()
+
+    with pytest.raises(ToolError, match="product.*or.*bug_id"):
+        await server.get_component_defaults(component="Release Notes", bz=bz)
+
+    bz.get_product.assert_not_awaited()


### PR DESCRIPTION
Hi, this is the last of my backlog of things to upstream.

Bugzilla's web UI has a checkbox for resetting a bug back to whoever the component
defaults to. The MCP server had no equivalent, so getting that through an agent
meant naming a specific person, and that name is wrong as soon as component
ownership moves.

One tool here asks who a component currently defaults to. The other resets the
bug to them.