### PR TITLE
Tool consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ This document describes common development tasks for the `mcp-bugzilla` project.
 - **Entry point**: `src/mcp_bugzilla/__init__.py` → `main()`
 - **MCP tools/prompts**: `src/mcp_bugzilla/server.py`
 - **Bugzilla REST client** (`Bugzilla` class): `src/mcp_bugzilla/lib_bugzilla.py` — single source of truth for all Bugzilla API interactions
-- **General utilities** (logging, helpers): `src/mcp_bugzilla/mcp_utils.py`
+- **General utilities** (logging, filtering helpers): `src/mcp_bugzilla/mcp_utils.py`
+  - Contains pure Python helper functions for client-side data filtering (e.g., `filter_limit`, `filter_by_flag`), keeping `server.py` focused on MCP routing.
   - `mcp_utils.py` lazily re-exports `Bugzilla` and `BugzillaAPIError` from `lib_bugzilla.py` for backward compatibility — prefer importing directly from `lib_bugzilla`
 - **Tests**: `tests/`
 
@@ -42,9 +43,10 @@ uv run ruff format --check # format
 1. Open `src/mcp_bugzilla/server.py`.
 2. Define a new async function decorated with `@mcp.tool()`.
 3. Add a method to the `Bugzilla` client class in `lib_bugzilla.py` for the authenticated REST call — use the pre-authenticated `self.client` and follow existing methods like `bug_info` / `update_bug` (including their `httpx` error handling) — then call it from the tool.
-4. Raise `ToolError` on Bugzilla API errors.
-5. Add tests: the client method in `tests/test_lib_bugzilla.py` (mock HTTP with `respx`), and the tool in `tests/test_server.py` (with an `AsyncMock` client).
-6. Update relevant documentation wherever applicable
+4. If your tool requires client-side data filtering or shaping, implement pure helper functions in `src/mcp_bugzilla/mcp_utils.py` rather than inline in `server.py`.
+5. Raise `ToolError` on Bugzilla API errors.
+6. Add tests: the client method in `tests/test_lib_bugzilla.py` (mock HTTP with `respx`), and the tool in `tests/test_server.py` (with an `AsyncMock` client).
+7. Update relevant documentation wherever applicable
 
 ## Commit style
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The server provides the following tools for interacting with Bugzilla:
     - `exclude_fields`: Comma-separated field names to drop. To remove a user-object expansion, exclude both the base field and its `*_detail` together, e.g. `"cc,cc_detail"` — excluding the `*_detail` alone has no effect, as Bugzilla re-attaches it while the base field is present
   - **Returns**: A dictionary containing the array `bugs` which lists the requested information about the bugs (status, assignee, summary, description, extensions, etc.)
   - **Note on Bugzilla API parity**: both `include_fields` and `exclude_fields` are native Bugzilla `Bug.get` parameters, forwarded to the API unchanged; the underlying request is standard Bugzilla
-  - **Example**: `bug_info({12345, 67890}, include_fields="id,status,resolution,summary")` fetches two bugs with just the essential scalar fields
+  - **Example**: `bug_info([12345, 67890], include_fields="id,status,resolution,summary")` fetches two bugs with just the essential scalar fields
 
 - **`bug_history(bug_id: int, new_since: Optional[datetime] = None, changed_fields: Optional[str] = None, exclude_authors: Optional[str] = None, limit: Optional[int] = None)`**: Fetches the change history of a given bug ID, with SQL-like controls to keep only the change events that matter for triage.
   - **Parameters**:

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ The server provides the following tools for interacting with Bugzilla:
 
 #### Bug Information
 
-- **`bug_info(bug_ids: set[int], include_fields: Optional[str] = None, exclude_fields: Optional[str] = None)`**: Retrieves comprehensive details for specified Bugzilla bug IDs. By default every field is returned; use Bugzilla's native field selection to trim large or bulk fetches.
+- **`bug_info(bug_ids: list[int], include_fields: Optional[str] = None, exclude_fields: Optional[str] = None)`**: Retrieves comprehensive details for specified Bugzilla bug IDs. By default every field is returned; use Bugzilla's native field selection to trim large or bulk fetches.
   - **Parameters**:
-    - `bug_ids`: A set of bug IDs to fetch details for
+    - `bug_ids`: A list of bug IDs to fetch details for
     - `include_fields`: Comma-separated field names to return (Bugzilla's native `Bug.get` parameter; supports field groups and `_default`/`_all`/`_extra`). For the leanest response request only scalar fields, e.g. `"id,status,resolution,summary"`. Requesting a user field (`assigned_to`, `creator`, `cc`, `qa_contact`) also returns its verbose `*_detail` object. Defaults to all fields
     - `exclude_fields`: Comma-separated field names to drop. To remove a user-object expansion, exclude both the base field and its `*_detail` together, e.g. `"cc,cc_detail"` — excluding the `*_detail` alone has no effect, as Bugzilla re-attaches it while the base field is present
   - **Returns**: A dictionary containing the array `bugs` which lists the requested information about the bugs (status, assignee, summary, description, extensions, etc.)
   - **Note on Bugzilla API parity**: both `include_fields` and `exclude_fields` are native Bugzilla `Bug.get` parameters, forwarded to the API unchanged; the underlying request is standard Bugzilla
   - **Example**: `bug_info({12345, 67890}, include_fields="id,status,resolution,summary")` fetches two bugs with just the essential scalar fields
 
-- **`bug_history(id: int, new_since: Optional[datetime] = None, changed_fields: Optional[str] = None, exclude_authors: Optional[str] = None, limit: Optional[int] = None)`**: Fetches the change history of a given bug ID, with SQL-like controls to keep only the change events that matter for triage.
+- **`bug_history(bug_id: int, new_since: Optional[datetime] = None, changed_fields: Optional[str] = None, exclude_authors: Optional[str] = None, limit: Optional[int] = None)`**: Fetches the change history of a given bug ID, with SQL-like controls to keep only the change events that matter for triage.
   - **Parameters**:
-    - `id`: The bug ID to fetch history for
+    - `bug_id`: The bug ID to fetch history for
     - `new_since`: Optional datetime object to only return history newer than this time
     - `changed_fields`: Comma-separated Bugzilla field names; keep only changes to these fields, dropping events left with no matching change (e.g. `"status,resolution,assigned_to"` to see only lifecycle changes and hide the cc / flagtypes.name / summary churn that dominates most histories)
     - `exclude_authors`: Comma-separated substrings; drop events whose author matches any (e.g. `"upstream-release-monitoring"` to hide release-monitoring bot edits)
@@ -45,7 +45,7 @@ The server provides the following tools for interacting with Bugzilla:
   - **Note on Bugzilla API parity**: `new_since` mirrors Bugzilla's own API parameter. `changed_fields`, `exclude_authors`, and `limit` have no server-side Bugzilla equivalent — this server applies them client-side, as post-processing over the standard `Bug.history` response; the underlying Bugzilla request is unmodified
   - **Example**: `bug_history(2504555, changed_fields="status,resolution")` returns just the event where the bug was closed as RAWHIDE, filtering out the surrounding cc and needinfo-flag churn
 
-- **`bug_comments(id: int, include_private_comments: bool = False, new_since: Optional[datetime] = None, include_fields: Optional[str] = "count,id,creator,creation_time,text,attachment_id", exclude_creators: Optional[str] = None, limit: Optional[int] = None)`**: Fetches comments associated with a given bug ID, with SQL-like controls to keep only what is needed and avoid flooding the context on large threads.
+- **`bug_comments(bug_id: int, include_private_comments: bool = False, new_since: Optional[datetime] = None, include_fields: Optional[str] = "count,id,creator,creation_time,text,attachment_id,is_private", exclude_creators: Optional[str] = None, limit: Optional[int] = None)`**: Fetches comments associated with a given bug ID, with SQL-like controls to keep only what is needed and avoid flooding the context on large threads.
   - **Parameters**:
     - `id`: The bug ID to fetch comments for
     - `include_private_comments`: Whether to include private comments (default: `False`)
@@ -192,7 +192,7 @@ The server provides the following tools for interacting with Bugzilla:
 - **`quicksearch_syntax_resource()`**: Returns documentation on Bugzilla's quicksearch syntax.
   - **Returns**: A string containing HTML documentation.
 
-- **`summarize_bug_prompt(id: int)`**: Returns a detailed summary prompt for all comments of a given bug ID.
+- **`summarize_bug_prompt(bug_id: int)`**: Returns a detailed summary prompt for all comments of a given bug ID.
   - **Returns**: A well-structured summary of the bug's comments including usernames (bold italic) and dates (bold).
 
 #### Utility Tools
@@ -558,17 +558,17 @@ result = client.call_tool(
 # Get the history of changes for a bug
 history = client.call_tool(
     "bug_history",
-    {"id": 12345, "new_since": datetime.fromisoformat("2026-01-01T00:00:00")},
+    {"bug_id": 12345, "new_since": datetime.fromisoformat("2026-01-01T00:00:00")},
 )
 
 # Get all public comments
 public_comments = client.call_tool(
-    "bug_comments", {"id": 12345, "include_private_comments": False}
+    "bug_comments", {"bug_id": 12345, "include_private_comments": False}
 )
 
 # Get all comments including private ones
 all_comments = client.call_tool(
-    "bug_comments", {"id": 12345, "include_private_comments": True}
+    "bug_comments", {"bug_id": 12345, "include_private_comments": True}
 )
 ```
 

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -100,30 +100,43 @@ def safe_filename(name: str | None, attachment_id: int) -> str:
     base = re.sub(r"[^A-Za-z0-9._-]", "_", base).strip("._")
     return base or f"attachment-{attachment_id}"
 
-def filter_limit(items: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+
+def filter_limit(
+    items: list[dict[str, Any]], limit: int | None
+) -> list[dict[str, Any]]:
     """Keep only the most recent N items (preserves chronological order)."""
     if limit and limit > 0:
         return items[-limit:]
     return items
 
-def filter_include_fields(items: list[dict[str, Any]], fields: str | None) -> list[dict[str, Any]]:
+
+def filter_include_fields(
+    items: list[dict[str, Any]], fields: str | None
+) -> list[dict[str, Any]]:
     """Keep only the specified fields for each item in the list."""
     if fields is None:
         return items
     wanted = [f.strip() for f in fields.split(",") if f.strip()]
     return [{k: item[k] for k in wanted if k in item} for item in items]
 
-def filter_exclude_substrings(items: list[dict[str, Any]], field: str, patterns_str: str | None) -> list[dict[str, Any]]:
+
+def filter_exclude_substrings(
+    items: list[dict[str, Any]], field: str, patterns_str: str | None
+) -> list[dict[str, Any]]:
     """Exclude items where the specified field contains any of the comma-separated substrings."""
     if not patterns_str:
         return items
     patterns = [p.strip() for p in patterns_str.split(",") if p.strip()]
     return [
-        item for item in items
+        item
+        for item in items
         if not any(p in (item.get(field) or "") for p in patterns)
     ]
 
-def filter_history_changes(history: list[dict[str, Any]], changed_fields: str | None) -> list[dict[str, Any]]:
+
+def filter_history_changes(
+    history: list[dict[str, Any]], changed_fields: str | None
+) -> list[dict[str, Any]]:
     """Filter bug history to keep only events that modified the specified fields."""
     if not changed_fields:
         return history
@@ -135,6 +148,9 @@ def filter_history_changes(history: list[dict[str, Any]], changed_fields: str | 
             pruned.append({**h, "changes": kept})
     return pruned
 
-def filter_by_flag(items: list[dict[str, Any]], field: str, required_value: bool) -> list[dict[str, Any]]:
+
+def filter_by_flag(
+    items: list[dict[str, Any]], field: str, required_value: bool
+) -> list[dict[str, Any]]:
     """Keep items where the boolean value of the specified field matches required_value."""
     return [item for item in items if bool(item.get(field)) is required_value]

--- a/src/mcp_bugzilla/mcp_utils.py
+++ b/src/mcp_bugzilla/mcp_utils.py
@@ -11,6 +11,7 @@ License: Apache 2.0
 import logging
 import os
 import re
+from typing import Any
 
 # Re-export Bugzilla and BugzillaAPIError for backward compatibility.
 # Lazily imported to avoid circular dependencies — lib_bugzilla imports
@@ -98,3 +99,42 @@ def safe_filename(name: str | None, attachment_id: int) -> str:
     base = os.path.basename(name or "").strip()
     base = re.sub(r"[^A-Za-z0-9._-]", "_", base).strip("._")
     return base or f"attachment-{attachment_id}"
+
+def filter_limit(items: list[dict[str, Any]], limit: int | None) -> list[dict[str, Any]]:
+    """Keep only the most recent N items (preserves chronological order)."""
+    if limit and limit > 0:
+        return items[-limit:]
+    return items
+
+def filter_include_fields(items: list[dict[str, Any]], fields: str | None) -> list[dict[str, Any]]:
+    """Keep only the specified fields for each item in the list."""
+    if fields is None:
+        return items
+    wanted = [f.strip() for f in fields.split(",") if f.strip()]
+    return [{k: item[k] for k in wanted if k in item} for item in items]
+
+def filter_exclude_substrings(items: list[dict[str, Any]], field: str, patterns_str: str | None) -> list[dict[str, Any]]:
+    """Exclude items where the specified field contains any of the comma-separated substrings."""
+    if not patterns_str:
+        return items
+    patterns = [p.strip() for p in patterns_str.split(",") if p.strip()]
+    return [
+        item for item in items
+        if not any(p in (item.get(field) or "") for p in patterns)
+    ]
+
+def filter_history_changes(history: list[dict[str, Any]], changed_fields: str | None) -> list[dict[str, Any]]:
+    """Filter bug history to keep only events that modified the specified fields."""
+    if not changed_fields:
+        return history
+    wanted = {f.strip() for f in changed_fields.split(",") if f.strip()}
+    pruned = []
+    for h in history:
+        kept = [c for c in h.get("changes", []) if c.get("field_name") in wanted]
+        if kept:
+            pruned.append({**h, "changes": kept})
+    return pruned
+
+def filter_by_flag(items: list[dict[str, Any]], field: str, required_value: bool) -> list[dict[str, Any]]:
+    """Keep items where the boolean value of the specified field matches required_value."""
+    return [item for item in items if bool(item.get(field)) is required_value]

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -18,7 +18,16 @@ from typing import Any, Literal, TypedDict
 from fastmcp import FastMCP
 from fastmcp.dependencies import CurrentHeaders, Depends
 from fastmcp.exceptions import PromptError, ResourceError, ToolError
-from .mcp_utils import is_textual, mcp_log, safe_filename
+from .mcp_utils import (
+    filter_by_flag,
+    filter_exclude_substrings,
+    filter_history_changes,
+    filter_include_fields,
+    filter_limit,
+    is_textual,
+    mcp_log,
+    safe_filename,
+)
 
 from .lib_bugzilla import Bugzilla
 
@@ -281,30 +290,9 @@ async def bug_history(
     try:
         history = await bz.bug_history(bug_id, new_since=new_since)
 
-        # WHERE who NOT LIKE any(exclude_authors)
-        if exclude_authors:
-            patterns = [p.strip() for p in exclude_authors.split(",") if p.strip()]
-            history = [
-                h
-                for h in history
-                if not any(p in (h.get("who") or "") for p in patterns)
-            ]
-
-        # WHERE field_name IN (changed_fields); drop events left with no match
-        if changed_fields:
-            wanted = {f.strip() for f in changed_fields.split(",") if f.strip()}
-            pruned = []
-            for h in history:
-                kept = [
-                    c for c in h.get("changes", []) if c.get("field_name") in wanted
-                ]
-                if kept:
-                    pruned.append({**h, "changes": kept})
-            history = pruned
-
-        # LIMIT to the most recent N (chronological order preserved)
-        if limit and limit > 0:
-            history = history[-limit:]
+        history = filter_exclude_substrings(history, "who", exclude_authors)
+        history = filter_history_changes(history, changed_fields)
+        history = filter_limit(history, limit)
 
         mcp_log.info(f"[LLM-RES] Returning {len(history)} history items")
         return history
@@ -350,27 +338,12 @@ async def bug_comments(
     try:
         comments = await bz.bug_comments(bug_id, new_since=new_since)
 
-        # WHERE is_private = false (unless explicitly requested)
         if not include_private_comments:
-            comments = [c for c in comments if not c.get("is_private", False)]
+            comments = filter_by_flag(comments, "is_private", False)
 
-        # WHERE creator NOT LIKE any(exclude_creators)
-        if exclude_creators:
-            patterns = [p.strip() for p in exclude_creators.split(",") if p.strip()]
-            comments = [
-                c
-                for c in comments
-                if not any(p in (c.get("creator") or "") for p in patterns)
-            ]
-
-        # LIMIT to the most recent N (chronological order preserved)
-        if limit and limit > 0:
-            comments = comments[-limit:]
-
-        # SELECT include_fields
-        if include_fields is not None:
-            wanted = [f.strip() for f in include_fields.split(",") if f.strip()]
-            comments = [{k: c[k] for k in wanted if k in c} for c in comments]
+        comments = filter_exclude_substrings(comments, "creator", exclude_creators)
+        comments = filter_limit(comments, limit)
+        comments = filter_include_fields(comments, include_fields)
 
         mcp_log.info(f"[LLM-RES] Returning {len(comments)} comments")
         return comments
@@ -931,17 +904,13 @@ async def list_attachments(
     try:
         attachments = await bz.list_attachments(bug_id)
 
-        # WHERE NOT is_obsolete
         if exclude_obsolete:
-            attachments = [a for a in attachments if not a.get("is_obsolete")]
+            attachments = filter_by_flag(attachments, "is_obsolete", False)
 
-        # WHERE is_patch
         if patches_only:
-            attachments = [a for a in attachments if a.get("is_patch")]
+            attachments = filter_by_flag(attachments, "is_patch", True)
 
-        # LIMIT to the most recent N (chronological order preserved)
-        if limit and limit > 0:
-            attachments = attachments[-limit:]
+        attachments = filter_limit(attachments, limit)
 
         mcp_log.info(f"[LLM-RES] Returning {len(attachments)} attachments")
         return attachments

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -103,12 +103,12 @@ _get_bz = Depends(get_bz)
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bug_info(
-    bug_ids: set[int],
+    bug_ids: list[int],
     include_fields: str | None = None,
     exclude_fields: str | None = None,
     bz: Bugzilla = _get_bz,
 ) -> dict[str, Any]:
-    """Returns information for one or more bugzilla bug ids.
+    """Returns information for one or more Bugzilla bug IDs.
 
     By default every field is returned. For large or bulk fetches, use
     Bugzilla's native field selection (both are forwarded to Bug.get):
@@ -247,14 +247,14 @@ async def get_component_defaults(
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bug_history(
-    id: int,
+    bug_id: int,
     new_since: datetime | None = None,
     changed_fields: str | None = None,
     exclude_authors: str | None = None,
     limit: int | None = None,
     bz: Bugzilla = _get_bz,
 ) -> list[dict[str, Any]]:
-    """Returns the history of given bug id.
+    """Returns the history of a given bug.
 
     A bug's history is often dominated by low-signal churn (repeated bot
     edits, cc-list changes, flag flips). These SQL-like controls keep only
@@ -273,13 +273,13 @@ async def bug_history(
     """
 
     mcp_log.info(
-        f"[LLM-REQ] bug_history(id={id}, new_since={new_since}, "
+        f"[LLM-REQ] bug_history(bug_id={bug_id}, new_since={new_since}, "
         f"changed_fields={changed_fields}, exclude_authors={exclude_authors}, "
         f"limit={limit})"
     )
 
     try:
-        history = await bz.bug_history(id, new_since=new_since)
+        history = await bz.bug_history(bug_id, new_since=new_since)
 
         # WHERE who NOT LIKE any(exclude_authors)
         if exclude_authors:
@@ -314,7 +314,7 @@ async def bug_history(
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bug_comments(
-    id: int,
+    bug_id: int,
     include_private_comments: bool = False,
     new_since: datetime | None = None,
     include_fields: str | None = "count,id,creator,creation_time,text,attachment_id",
@@ -322,7 +322,7 @@ async def bug_comments(
     limit: int | None = None,
     bz: Bugzilla = _get_bz,
 ) -> list[dict[str, Any]]:
-    """Returns the comments of given bug id.
+    """Returns the comments of a given bug.
 
     Comment threads on long-lived bugs can be very large (hundreds of automated
     comments), so this tool exposes SQL-like controls to return only what is
@@ -341,14 +341,14 @@ async def bug_comments(
     """
 
     mcp_log.info(
-        f"[LLM-REQ] bug_comments(id={id}, "
+        f"[LLM-REQ] bug_comments(bug_id={bug_id}, "
         f"include_private_comments={include_private_comments}, new_since={new_since}, "
         f"include_fields={include_fields}, exclude_creators={exclude_creators}, "
         f"limit={limit})"
     )
 
     try:
-        comments = await bz.bug_comments(id, new_since=new_since)
+        comments = await bz.bug_comments(bug_id, new_since=new_since)
 
         # WHERE is_private = false (unless explicitly requested)
         if not include_private_comments:
@@ -386,7 +386,7 @@ async def bug_comments(
 async def add_comment(
     bug_id: int, comment: str, is_private: bool = False, bz: Bugzilla = _get_bz
 ) -> dict[str, int]:
-    """Add a comment to a bug. It can optionally be private. If success, returns the created comment id."""
+    """Add a comment to a bug. It can optionally be private. Returns the created comment id on success."""
     mcp_log.info(
         f"[LLM-REQ] add_comment(bug_id={bug_id}, comment='{comment}', is_private={is_private})"
     )
@@ -406,7 +406,7 @@ async def bugs_quicksearch(
     offset: int | None = 0,
     bz: Bugzilla = _get_bz,
 ) -> dict[str, Any]:
-    """Search bugs using bugzilla's quicksearch syntax
+    """Search bugs using Bugzilla's Quicksearch syntax.
 
     To reduce the token limit & response time, only returns a subset of fields for each bug
     The user can query full details of each bug using the bug_info tool
@@ -436,7 +436,7 @@ async def bugs_quicksearch(
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def quicksearch_syntax_resource(bz: Bugzilla = _get_bz) -> str:
-    """Access the documentation of the bugzilla quicksearch syntax. LLM can learn using this tool. Response is in HTML"""
+    """Access the documentation of the Bugzilla Quicksearch syntax. Use this to learn how to construct advanced search queries. Response is in HTML."""
 
     mcp_log.info("[LLM-REQ] quicksearch_syntax_resource()")
 
@@ -471,7 +471,7 @@ async def bugzilla_server_info(bz: Bugzilla = _get_bz) -> dict[str, Any]:
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": False}, tags={"read"})
 def bug_url(bug_id: int) -> str:
-    """returns the bug url"""
+    """Returns the web URL for a given bug."""
     mcp_log.info(f"[LLM-REQ] bug_url(bug_id={bug_id})")
     return f"{base_url}/show_bug.cgi?id={bug_id}"
 
@@ -503,13 +503,13 @@ def get_current_headers_resource(headers: dict = _current_headers) -> dict[str, 
 
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
-async def summarize_bug_prompt(id: int, bz: Bugzilla = _get_bz) -> str:
-    """Summarizes all the comments of a bug"""
+async def summarize_bug_prompt(bug_id: int, bz: Bugzilla = _get_bz) -> str:
+    """Returns a prompt containing all comments of a bug, which can be used to generate a summary."""
 
-    mcp_log.info(f"[LLM-REQ] summarize_bug_prompt(id={id})")
+    mcp_log.info(f"[LLM-REQ] summarize_bug_prompt(bug_id={bug_id})")
 
     try:
-        comments = await bz.bug_comments(id)
+        comments = await bz.bug_comments(bug_id)
 
         summary_prompt = f"""
     You are an expert in summarizing bugzilla comments.

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -18,6 +18,8 @@ from typing import Any, Literal, TypedDict
 from fastmcp import FastMCP
 from fastmcp.dependencies import CurrentHeaders, Depends
 from fastmcp.exceptions import PromptError, ResourceError, ToolError
+
+from .lib_bugzilla import Bugzilla
 from .mcp_utils import (
     filter_by_flag,
     filter_exclude_substrings,
@@ -28,8 +30,6 @@ from .mcp_utils import (
     mcp_log,
     safe_filename,
 )
-
-from .lib_bugzilla import Bugzilla
 
 # The FastMCP instance
 mcp = FastMCP("Bugzilla")
@@ -305,7 +305,8 @@ async def bug_comments(
     bug_id: int,
     include_private_comments: bool = False,
     new_since: datetime | None = None,
-    include_fields: str | None = "count,id,creator,creation_time,text,attachment_id,is_private",
+    include_fields: str
+    | None = "count,id,creator,creation_time,text,attachment_id,is_private",
     exclude_creators: str | None = None,
     limit: int | None = None,
     bz: Bugzilla = _get_bz,
@@ -353,7 +354,11 @@ async def bug_comments(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True},
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "openWorldHint": True,
+    },
     tags={"write"},
 )
 async def add_comment(

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -353,7 +353,7 @@ async def bug_comments(
 
 
 @mcp.tool(
-    annotations={"readOnlyHint": False, "destructiveHint": True, "openWorldHint": True},
+    annotations={"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True},
     tags={"write"},
 )
 async def add_comment(
@@ -381,8 +381,8 @@ async def bugs_quicksearch(
 ) -> dict[str, Any]:
     """Search bugs using Bugzilla's Quicksearch syntax.
 
-    To reduce the token limit & response time, only returns a subset of fields for each bug
-    The user can query full details of each bug using the bug_info tool
+    To reduce the token limit & response time, this only returns a subset of fields for each bug.
+    The user can query full details of each bug using the `bug_info` tool.
     Returns the top-level bug data envelope containing the matched bugs.
     """
 
@@ -434,7 +434,7 @@ async def quicksearch_syntax_resource(bz: Bugzilla = _get_bz) -> str:
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def bugzilla_server_info(bz: Bugzilla = _get_bz) -> dict[str, Any]:
-    """Returns comprehensive bugzilla server information (url, version, extensions, timezone, time, parameters)."""
+    """Returns comprehensive Bugzilla server information (url, version, extensions, timezone, time, parameters)."""
     mcp_log.info("[LLM-REQ] bugzilla_server_info()")
     try:
         return await bz.bugzilla_info()
@@ -451,7 +451,7 @@ def bug_url(bug_id: int) -> str:
 
 @mcp.tool(annotations={"readOnlyHint": True, "openWorldHint": True}, tags={"read"})
 async def mcp_server_info_resource(bz: Bugzilla = _get_bz) -> dict[str, Any]:
-    """Returns the args being used by the current server instance"""
+    """Returns the configuration arguments and version of the current MCP server instance."""
 
     mcp_log.info("[LLM-REQ] mcp_server_info_resource()")
 
@@ -845,7 +845,7 @@ async def add_attachment(
         bug_id: Bug to attach the file to
         file_name: File name shown in Bugzilla
         summary: Short description of the attachment
-        data: The attachment content, **base64-encoded** (binary-safe)
+        data: The attachment content. MUST be base64-encoded (binary-safe)!
         content_type: MIME type (ignored by Bugzilla when is_patch=True)
         is_patch: Mark the attachment as a patch
         is_private: Restrict the attachment to the insider group

--- a/src/mcp_bugzilla/server.py
+++ b/src/mcp_bugzilla/server.py
@@ -305,7 +305,7 @@ async def bug_comments(
     bug_id: int,
     include_private_comments: bool = False,
     new_since: datetime | None = None,
-    include_fields: str | None = "count,id,creator,creation_time,text,attachment_id",
+    include_fields: str | None = "count,id,creator,creation_time,text,attachment_id,is_private",
     exclude_creators: str | None = None,
     limit: int | None = None,
     bz: Bugzilla = _get_bz,
@@ -317,7 +317,7 @@ async def bug_comments(
     needed and avoid flooding the context window:
 
       include_fields    Comma-separated field names to keep per comment
-                        (default: count,id,creator,creation_time,text,attachment_id).
+                        (default: count,id,creator,creation_time,text,attachment_id,is_private).
                         Pass None to return every field.
       exclude_creators  Comma-separated substrings; drop comments whose creator
                         matches any -- e.g. "upstream-release-monitoring" to hide
@@ -325,7 +325,7 @@ async def bug_comments(
       limit             Return only the most recent N comments (chronological
                         order is preserved).
       new_since         Only comments newer than the given date.
-      include_private_comments  Include private comments (default: False).
+      include_private_comments  MUST be set to True to retrieve private/internal comments (default: False).
     """
 
     mcp_log.info(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -441,6 +441,17 @@ _RAW = [
         "bug_id": 42,
         "is_private": False,
     },
+    {
+        "count": 2,
+        "id": 3,
+        "creator": "insider@example.com",
+        "creator_id": 4,
+        "text": "private internal note",
+        "creation_time": "2025-03-01T00:00:00Z",
+        "tags": [],
+        "bug_id": 42,
+        "is_private": True,
+    },
 ]
 
 
@@ -458,6 +469,27 @@ async def test_bug_comments_default_projection_drops_redundant_fields():
         "is_private",
     }
     assert "creator_id" not in out[0] and "bug_id" not in out[0]
+
+
+@pytest.mark.asyncio
+async def test_bug_comments_privacy_boundary_default_excludes_private():
+    bz = AsyncMock()
+    bz.bug_comments = AsyncMock(return_value=[dict(c) for c in _RAW])
+    out = await server.bug_comments(bug_id=42, bz=bz)
+    # The default is include_private_comments=False. We added a 3rd comment that is private.
+    assert len(out) == 2
+    assert all(c["is_private"] is False for c in out)
+
+
+@pytest.mark.asyncio
+async def test_bug_comments_privacy_boundary_override_includes_private():
+    bz = AsyncMock()
+    bz.bug_comments = AsyncMock(return_value=[dict(c) for c in _RAW])
+    out = await server.bug_comments(bug_id=42, include_private_comments=True, bz=bz)
+    # When True, all 3 comments (including the private one) should be returned
+    assert len(out) == 3
+    assert out[-1]["is_private"] is True
+    assert out[-1]["creator"] == "insider@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -448,8 +448,15 @@ _RAW = [
 async def test_bug_comments_default_projection_drops_redundant_fields():
     bz = AsyncMock()
     bz.bug_comments = AsyncMock(return_value=[dict(c) for c in _RAW])
-    out = await server.bug_comments(id=42, bz=bz)
-    assert set(out[0]) == {"count", "id", "creator", "creation_time", "text"}
+    out = await server.bug_comments(bug_id=42, bz=bz)
+    assert set(out[0]) == {
+        "count",
+        "id",
+        "creator",
+        "creation_time",
+        "text",
+        "is_private",
+    }
     assert "creator_id" not in out[0] and "bug_id" not in out[0]
 
 
@@ -457,7 +464,7 @@ async def test_bug_comments_default_projection_drops_redundant_fields():
 async def test_bug_comments_exclude_creators():
     bz = AsyncMock()
     bz.bug_comments = AsyncMock(return_value=[dict(c) for c in _RAW])
-    out = await server.bug_comments(id=42, exclude_creators="bot@monitoring", bz=bz)
+    out = await server.bug_comments(bug_id=42, exclude_creators="bot@monitoring", bz=bz)
     assert len(out) == 1 and out[0]["creator"] == "human@example.com"
 
 
@@ -465,7 +472,7 @@ async def test_bug_comments_exclude_creators():
 async def test_bug_comments_limit_keeps_most_recent():
     bz = AsyncMock()
     bz.bug_comments = AsyncMock(return_value=[dict(c) for c in _RAW])
-    out = await server.bug_comments(id=42, limit=1, include_fields=None, bz=bz)
+    out = await server.bug_comments(bug_id=42, limit=1, include_fields=None, bz=bz)
     assert len(out) == 1 and out[0]["count"] == 1
 
 
@@ -498,7 +505,7 @@ _HIST = [
 async def test_bug_history_changed_fields_keeps_only_matching_changes():
     bz = AsyncMock()
     bz.bug_history = AsyncMock(return_value=[dict(h) for h in _HIST])
-    out = await server.bug_history(id=42, changed_fields="status,resolution", bz=bz)
+    out = await server.bug_history(bug_id=42, changed_fields="status,resolution", bz=bz)
     # only the lifecycle event survives, and only its matching changes are kept
     assert len(out) == 1
     kept = {c["field_name"] for c in out[0]["changes"]}
@@ -509,7 +516,7 @@ async def test_bug_history_changed_fields_keeps_only_matching_changes():
 async def test_bug_history_exclude_authors():
     bz = AsyncMock()
     bz.bug_history = AsyncMock(return_value=[dict(h) for h in _HIST])
-    out = await server.bug_history(id=42, exclude_authors="bot@monitoring", bz=bz)
+    out = await server.bug_history(bug_id=42, exclude_authors="bot@monitoring", bz=bz)
     assert len(out) == 2
     assert all(h["who"] == "human@example.com" for h in out)
 
@@ -518,7 +525,7 @@ async def test_bug_history_exclude_authors():
 async def test_bug_history_limit_keeps_most_recent():
     bz = AsyncMock()
     bz.bug_history = AsyncMock(return_value=[dict(h) for h in _HIST])
-    out = await server.bug_history(id=42, limit=1, bz=bz)
+    out = await server.bug_history(bug_id=42, limit=1, bz=bz)
     assert len(out) == 1 and out[0]["when"] == "2026-03-01T00:00:00Z"  # newest
 
 


### PR DESCRIPTION
- Reviewing the interface exposed to LLMs for better consistency across the tools and clearer method's documentation;
- Moving filtering logic to dedicated handlers under mcp_utils, to let server.py  focus on MCP related code;
- Fixed a regression where comment retrieval did not pass any more by default 'is_private' field to the invoker, making private and public comments indistinguishable
- Linting and updating docs accordingly